### PR TITLE
Adds a new `bug-report-azure` skill that files bugs found during testing into Azure DevOps, using the Azure CLI.

### DIFF
--- a/skills/bug-report-azure/SKILL.md
+++ b/skills/bug-report-azure/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: bug-report-azure
+description: After a completed test/regression run where one or more defects were found, file them as Azure DevOps Bugs via the Azure CLI (az devops / az boards), following a configurable bug template. Product/team-agnostic — org, project, area path, template, assignees, and test plan are all placeholders resolved from config, never hardcoded. Human-in-the-loop at every board-changing step: template selection, parent User Story, related test case / suite, severity + priority (recommended from the run's findings, with alternatives to choose), and screenshot validation — all rolled into ONE consolidated confirmation before any write. Uses az CLI for every lookup, validation, and write; never touches the board beyond what the user explicitly confirms.
+---
+
+# Report Azure Bug (Generic)
+
+Turn defects found during a run into Azure DevOps **Bugs** that mirror a configurable
+team template and hang off the right User Story — with a human confirming every
+board-changing step. This is the closing gate of a test run.
+
+This skill is **decoupled from any specific team or product**. Everything team-specific is a
+placeholder resolved at runtime from config (never hardcoded in the skill):
+
+| Placeholder | Meaning | Resolved from |
+|---|---|---|
+| `{{ORG_URL}}` | Azure DevOps org URL | config / `AZURE_DEVOPS_ORG_URL` / `az` defaults |
+| `{{PROJECT_NAME}}` | Project | config / `AZURE_DEVOPS_DEFAULT_PROJECT` / `az` defaults |
+| `{{TEAM_NAME}}` | Team | config |
+| `{{AREA_PATH}}` | Area Path | config or inherited from the parent story |
+| `{{ITERATION_PATH}}` | Iteration Path | config or inherited from the parent story |
+| `{{TEMPLATE_BUG_ID}}` | Reference bug the template mirrors | config (optional) |
+| `{{ASSIGNEE_EMAIL}}` / `{{DEVELOPER_NAME}}` | Bug assignee options | config (`assignees` list) — **always asked** |
+| `{{TEST_PLAN_ID}}` / `{{TEST_SUITE_ID}}` | Related test plan / suite | **always asked** |
+| `{{ENVIRONMENT}}` / `{{BUG_CATEGORY}}` | Custom fields | config defaults or asked |
+
+Copy `config.example.json` to `config.json` (next to this file, or repo root) and fill in your
+values. Anything left unset is **asked**, never inferred — see constraint 8.
+
+## Tooling: az CLI only
+
+- **All** lookups, validations, links, and writes go through the **Azure CLI** (`az devops`,
+  `az boards`, and `az devops invoke` for the few routes `az boards` doesn't cover, e.g.
+  attachment upload and test-run outcomes). **No direct REST/API calls from the scripts, and no
+  UI-equivalent actions outside the CLI.**
+- Auth is whatever `az` already uses: `az login` + `az devops login` (PAT), or the
+  `AZURE_DEVOPS_EXT_PAT` env var. The scripts never read or print a PAT themselves. Set
+  `PYTHONIOENCODING=utf-8` so non-ASCII fields don't trip cp1252 on Windows.
+- Two dry-run-by-default helpers wrap the CLI so a human sees the plan first:
+  - `scripts/create-bug.mjs` — create a Bug + parent link (+ validated attachments).
+  - `scripts/testplan.mjs` — `list-suites` / `list-cases` / `find-case` / `create-case` / `fail`.
+  - `scripts/check-image.mjs` — structural screenshot validation (Pass 1 of the evidence gate).
+
+  Both write helpers print the **exact `az` commands they will run** and change nothing until
+  `--execute` is passed.
+
+## Hard constraints (never violate — these are the point of the skill)
+
+1. **Write nothing on Azure DevOps beyond what the user explicitly confirmed** — the bug itself,
+   the confirmed template, the confirmed parent User Story link, the confirmed test-case/suite
+   action, and the validated screenshot attachment. Nothing else, ever.
+2. **All read / lookup / validation via `az` may run freely.** No **write / create / update /
+   link / attach** may happen until (a) every human-in-the-loop question below is answered **and**
+   (b) the user has given **one final explicit confirmation** of the complete consolidated summary.
+3. **One link type only:** User Story → (parent) → Bug, via `az boards work-item relation add
+   --relation-type parent`. No related / duplicate / predecessor-successor / any other link.
+4. **Never edit a User Story** except adding that single parent link — no field/state/description
+   changes on the story.
+5. **Never edit a Test Plan / Suite / Test Case** except the two explicit, user-chosen actions:
+   (a) recording a *Failed outcome* on an existing linked test case, or (b) creating a new test
+   case when the user explicitly asks. No other modifications.
+6. **Log every write `az` command before running it.** The write helpers print the command; show
+   it to the user as part of the confirmation. No silent writes.
+7. **Idempotency:** before creating a Bug or Test Case, check via `az` whether one with the same
+   title already exists. If a potential duplicate is found, surface it and ask the user before
+   creating.
+8. **Never infer or auto-fill missing required fields** (priority, severity, area path, assignee,
+   environment). Ask the user, or use a clearly-marked `{{PLACEHOLDER}}` — never a silent guess.
+9. **On any `az` failure, surface the exact error** to the user. Never auto-retry a
+   destructive/write action.
+
+## When to run
+
+At the end of any run/task that surfaced one or more issues. Offer it proactively: "N issues were
+found — want to file any as Azure Bugs?" If the user declines, stop. Do nothing on the board.
+
+## Workflow (human-in-the-loop)
+
+Steps 1–6 **collect and validate** (reads only). Nothing is written until the single
+confirmation in step 7.
+
+### 1. Which issues to report
+List the defects from the run (short title + one-line impact each). Ask the user to pick which to
+file. **If none selected → stop, create nothing.**
+
+### 2. Bug template selection (ASK — human-in-the-loop)
+Detect/propose a **default template** from context (the configured `{{TEMPLATE_BUG_ID}}`, or the
+project's standard Bug layout). Show what it entails (fields, ReproSteps shape). Then ask:
+
+> *"Use the default identified template, or would you like to customize / select a different one?"*
+
+Offer: **(a)** use the default, **(b)** customize specific fields, **(c)** select a different
+template. **Do not proceed with any template until the user confirms.** If a specific template bug
+is named, validate it exists first: `az boards work-item show --id {{TEMPLATE_BUG_ID}}`.
+
+### 3. Parent User Story link (ASK + validate via CLI)
+**Ask the user for the parent User Story ID** to link each selected bug to — never infer or
+default it. One question can cover all selected issues if they share a parent. **Validate it
+exists and is a User Story before proceeding:**
+```
+az boards work-item show --id <storyId> --query "{id:id,type:fields.\"System.WorkItemType\",title:fields.\"System.Title\",state:fields.\"System.State\"}" -o json
+```
+If the ID is not found, or the type is not `User Story`, **report that back and ask again** — do
+not guess. `create-bug.mjs` re-validates this and refuses a non-story parent. Area Path / Iteration
+are inherited from the story unless config overrides them.
+
+### 4. Severity + Priority (RECOMMEND from the run's findings, then ASK)
+Both are **human-in-the-loop**. From the defect's observed impact **in this run**, compute a
+**recommended** severity and priority, state the one-line reasoning, and present the recommended
+option **first** plus the other options for the user to choose from (use `AskUserQuestion`). Never
+silently pick.
+
+Recommendation guide (impact seen in the run → recommendation):
+
+| Observed impact in the run | Recommended Severity | Recommended Priority |
+|---|---|---|
+| Blocks the flow, no workaround (can't advance / pay / issue) | `1 - Critical` | `1` |
+| Wrong/missing data in an issued artifact, or broken core path w/ workaround | `2 - High` | `1` or `2` |
+| Localized functional error, visible but non-blocking | `3 - Medium` | `2` or `3` |
+| Minor cosmetic / edge polish | `4 - Low` | `3` or `4` |
+
+Present it like: *"Payment couldn't complete and there's no workaround → blocks issuance.
+**Recommended: Severity `1 - Critical`, Priority `1`.** Other options: Severity `2 - High` /
+`3 - Medium`; Priority `2` / `3`."* The **user's choice wins** — record whatever they pick. If the
+user gives no steer and declines to choose, use the recommendation but say so explicitly.
+
+### 5. Assignee (ASK — human-in-the-loop)
+Ask who the bug should be assigned to. Offer the configured `assignees` options and an "other":
+- `{{ASSIGNEE_EMAIL}}` (one per configured developer, e.g. `{{DEVELOPER_NAME}}`)
+- Other (the user types an email)
+
+Do not default silently. One question can cover all selected issues if they share an assignee.
+
+### 6. Related test suite / test case (ASK + validate/create via CLI)
+**Ask the user which test case failed and is related to this bug**, and the **Test Plan ID** (Suite
+ID too if known).
+
+**If a specific test case is provided** — validate it exists via CLI before linking:
+```
+node scripts/testplan.mjs find-case --plan <plan> --testcase <tc>
+```
+(under the hood: `az boards work-item show` + a suite/point lookup via `az devops invoke`). If it
+doesn't exist, report back and ask again.
+
+**If no specific test case is provided** — ask whether a **new test case should be created**:
+- **If yes** → ask **which test suite** (and plan) it should be added to. Only after confirmation,
+  create it and add it to that suite (step 7 executes it):
+  ```
+  node scripts/testplan.mjs create-case --plan <plan> --suite <suite> --title "<title>" [--execute]
+  ```
+- **If no** → skip the test-case link; the bug is filed on its own.
+
+Either way, take **only** the action the user explicitly picks. Nothing here is written until step 7.
+
+### 7. Screenshots + CONSOLIDATED confirmation + write
+A bug should carry evidence. Validate screenshots **before** attaching (two passes):
+
+**Pass 1 — structural (script):**
+```
+node scripts/check-image.mjs --dir <screenshots-folder>
+```
+Drops corrupt / `0×0` / `too-small` / `likely-blank` images.
+
+**Pass 2 — content relevance (your vision):** for each surviving image, **Read the image** and
+judge it against this bug's *summary / expected / actual*:
+- Does it visibly show the described error / UI state / failure? If it's an unrelated
+  screen (landing page, generic logged-in frame) or doesn't support the description →
+  **flag it to the user and ask for confirmation or a replacement** before including it. **Never
+  silently attach an unrelated screenshot.**
+
+Then build one spec JSON per issue (shape below) and **dry-run** it:
+```
+node scripts/create-bug.mjs --spec <spec>.json
+```
+The dry run prints the plan, an idempotency (duplicate-title) check, the attachment structural
+checks, **and the exact `az` commands** it will run.
+
+Now present **ONE consolidated confirmation** covering everything collected — avoid scattered
+confirmations. Include:
+- Template choice (from step 2)
+- Parent User Story (validated, step 3)
+- Severity + Priority (chosen, step 4) with the one-line reasoning
+- Assignee (step 5)
+- Test case / suite decision (validate-existing / create-new / skip, step 6)
+- Screenshot validation result — the final ATTACH / REJECT list with reasons (step 7)
+- The exact `az` write commands that will run
+
+**Only after the user's single explicit "yes" to this summary**, execute in order:
+```
+node scripts/create-bug.mjs --spec <spec>.json --execute                 # bug + parent link + attachments
+node scripts/testplan.mjs create-case --plan <plan> --suite <suite> --title "<t>" --execute   # only if chosen
+node scripts/testplan.mjs fail --plan <plan> --testcase <tc> --bug <bugId> --execute           # only if chosen
+```
+Report back each new Bug / Test Case ID + URL. If any command fails, show the **exact** `az`
+error and stop — do not auto-retry the write.
+
+## Spec JSON shape (for create-bug.mjs)
+
+```json
+{
+  "title": "Concise defect statement",
+  "severity": "2 - High",
+  "priority": 1,
+  "parentStoryId": 0,
+  "assignedTo": "{{ASSIGNEE_EMAIL}}",
+  "summary": "One-line summary shown in the Repro header",
+  "steps": ["Step 1", "Step 2", "Step 3"],
+  "expected": "What should happen",
+  "actual": "What actually happened",
+  "environment": "{{ENVIRONMENT}}",
+  "bugCategory": "{{BUG_CATEGORY}}",
+  "areaPath": "{{AREA_PATH}}",
+  "iterationPath": "{{ITERATION_PATH}}",
+  "testConfig": "Windows 11 / Chrome",
+  "timestamp": "1/1/2026 3:00 PM",
+  "attachments": ["executions/.../screenshots/ERROR.png"]
+}
+```
+- `severity` must be one of `1 - Critical` / `2 - High` / `3 - Medium` / `4 - Low`.
+- `priority` must be `1`–`4`. **Both come from the user's step-4 choice — the script does not
+  invent them and errors if either is missing.**
+- `areaPath` / `iterationPath` default to the parent story's when omitted.
+
+## Notes
+- The scripts need only Node (built-in modules) + a working, authenticated `az` CLI on PATH.
+- Keep spec files out of committed state (write them to a temp/execution folder). They carry no
+  secrets but are run scratch.
+- `az devops invoke` is used only where `az boards` has no native verb (attachment upload,
+  test-run outcomes). It is still the Azure CLI — every such command is printed before it runs.

--- a/skills/bug-report-azure/config.example.json
+++ b/skills/bug-report-azure/config.example.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Copy this file to config.json (same folder) or bug-skill.config.json at your repo root, then fill in your team's values. Anything you leave out is ASKED at runtime or inherited from the parent story — never silently guessed. None of these are hardcoded in the scripts.",
+
+  "orgUrl": "https://dev.azure.com/{{ORG_NAME}}",
+  "project": "{{PROJECT_NAME}}",
+  "team": "{{TEAM_NAME}}",
+
+  "areaPath": "{{PROJECT_NAME}}\\{{TEAM_NAME}}",
+  "iterationPath": "{{PROJECT_NAME}}\\{{ITERATION_PATH}}",
+
+  "templateBugId": "{{TEMPLATE_BUG_ID}}",
+
+  "assignees": [
+    "{{ASSIGNEE_EMAIL}}",
+    "{{ANOTHER_DEVELOPER_EMAIL}}"
+  ],
+
+  "valueArea": "Business",
+  "environment": "{{ENVIRONMENT}}",
+  "bugCategory": "{{BUG_CATEGORY}}",
+
+  "testPlanId": "{{TEST_PLAN_ID}}",
+
+  "apiVersion": "7.1"
+}

--- a/skills/bug-report-azure/references/azure-devops.md
+++ b/skills/bug-report-azure/references/azure-devops.md
@@ -1,0 +1,163 @@
+# Azure DevOps — az CLI recipes & field schema (reference)
+
+Backing detail for the `report-azure-bug-generic` skill. Everything here is **product/team
+agnostic** — substitute the `{{PLACEHOLDERS}}` from your `config.json`. Read this only when you
+need exact field names or `az` invocations; day-to-day the three scripts wrap all of it.
+
+All commands use the **Azure CLI** only (`az devops` / `az boards`, and `az devops invoke` for the
+few routes `az boards` doesn't cover). No direct REST calls.
+
+## Connection & auth
+
+```bash
+# one-time defaults so you can omit --org/--project on every call
+az devops configure --defaults \
+  organization={{ORG_URL}} \
+  project="{{PROJECT_NAME}}"
+
+# auth: interactive, or a PAT via env (never printed by the scripts)
+az login                      # or:
+export AZURE_DEVOPS_EXT_PAT=<pat>       # PAT with Work Items + Test Management scopes
+export PYTHONIOENCODING=utf-8           # keep non-ASCII fields from tripping cp1252
+```
+
+The scripts resolve `{{ORG_URL}}` / `{{PROJECT_NAME}}` from `config.json`, then the
+`AZURE_DEVOPS_ORG_URL` / `AZURE_DEVOPS_DEFAULT_PROJECT` env vars, then `az` configured defaults —
+whichever is found first. They never store a PAT.
+
+## Bug field schema (template mirror)
+
+Mirror of the configured template bug `{{TEMPLATE_BUG_ID}}` (a child of a `{{TEAM_NAME}}`
+User Story). Adjust field reference names to your process if it differs from the default Agile Bug.
+
+| Field (reference name) | Value | Notes |
+|---|---|---|
+| `System.WorkItemType` | `Bug` | `az boards work-item create --type Bug` |
+| `System.Title` | short defect statement | idempotency-checked before create |
+| `System.AreaPath` | `{{AREA_PATH}}` | inherit from parent story if unset |
+| `System.IterationPath` | `{{ITERATION_PATH}}` | inherit from parent story if unset |
+| `System.AssignedTo` | email | **ask the user** — from `assignees` config or "other" |
+| `Microsoft.VSTS.Common.Priority` | `1`–`4` | **ask the user** (recommended from run impact) — never silent |
+| `Microsoft.VSTS.Common.Severity` | `1 - Critical`…`4 - Low` | **ask the user** (recommended from run impact) |
+| `Microsoft.VSTS.Common.ValueArea` | `Business` | config default |
+| `Custom.Environment` | `{{ENVIRONMENT}}` | match the run's env (omit if your process has no such field) |
+| `Custom.BugCategory` | `{{BUG_CATEGORY}}` | e.g. `Functional` / `UI/UX` (omit if not in your process) |
+| `Microsoft.VSTS.TCM.ReproSteps` | HTML (see below) | the visible body of the bug |
+
+> `Custom.*` fields exist only if your project defines them. `create-bug.mjs` emits them only when
+> the spec provides a value; leave them out of the spec for stock processes.
+
+Parent link (the **only** relation the skill may add):
+```bash
+az boards work-item relation add --id <bugId> --relation-type parent --target-id <storyId>
+```
+`--relation-type parent` maps to `System.LinkTypes.Hierarchy-Reverse`. Attachments are added
+separately (below).
+
+## Reading / validating work items (reads — run freely)
+
+```bash
+# validate a parent story exists AND is a User Story
+az boards work-item show --id <storyId> \
+  --query "{id:id,type:fields.\"System.WorkItemType\",title:fields.\"System.Title\"}" -o json
+
+# idempotency: any existing Bug with this exact title?  (WIQL via az boards query)
+az boards query --wiql \
+  "SELECT [System.Id] FROM workitems WHERE [System.TeamProject]='{{PROJECT_NAME}}' \
+   AND [System.WorkItemType]='Bug' AND [System.Title]='<title>'" -o json
+```
+
+## Creating the Bug (write — only past explicit confirmation)
+
+```bash
+az boards work-item create --type Bug --title "<title>" \
+  --org {{ORG_URL}} --project "{{PROJECT_NAME}}" \
+  --fields \
+    "System.AreaPath=<area>" \
+    "System.IterationPath=<iteration>" \
+    "System.AssignedTo=<email>" \
+    "Microsoft.VSTS.Common.Priority=<1-4>" \
+    "Microsoft.VSTS.Common.Severity=<sev>" \
+    "Microsoft.VSTS.Common.ValueArea=Business" \
+    "Microsoft.VSTS.TCM.ReproSteps=<html>" \
+  -o json
+# then: az boards work-item relation add --id <newId> --relation-type parent --target-id <storyId>
+```
+
+## ReproSteps HTML shape
+
+```
+[hr] <table>  <b>{timestamp}</b> | {one-line summary}                       </table>
+[hr] <table>  <b>Steps:</b>                                                 </table>
+     <table>  <ol><li>step 1</li> … </ol>
+              <u>Expected Result</u>  {text}
+              <u>Actual Result</u>    {text}  <img src={attachment-url}>      </table>
+[hr] <table>  <b>Test Configuration:</b> | {testConfig}                      </table>
+```
+`create-bug.mjs` regenerates this exact structure from the spec JSON — you don't hand-write HTML.
+
+## Attachments (via `az devops invoke` — `az boards` has no native verb)
+
+```bash
+# 1) upload the file, get back {id, url}
+az devops invoke --area wit --resource attachments \
+  --route-parameters project="{{PROJECT_NAME}}" \
+  --query-parameters fileName=<name.png> \
+  --http-method POST --in-file <path/to/name.png> \
+  --api-version 7.1 -o json
+
+# 2) attach it to the bug (relation) — PATCH the work item's relations
+az devops invoke --area wit --resource workitems \
+  --route-parameters id=<bugId> \
+  --http-method PATCH --api-version 7.1 \
+  --in-file <patch.json>   # [{"op":"add","path":"/relations/-","value":{"rel":"AttachedFile","url":"<attachmentUrl>","attributes":{"comment":"<name>"}}}]
+```
+The returned attachment `url` is also embedded as `<img src=…>` inside ReproSteps so the evidence
+renders in the bug body. `create-bug.mjs` does all of this and prints each command first.
+
+## Test plans / suites / cases (reads via `az devops invoke`)
+
+`az boards` has limited test-plan coverage, so reads go through `az devops invoke --area testplan`:
+
+```bash
+# suites in a plan
+az devops invoke --area testplan --resource suites \
+  --route-parameters project="{{PROJECT_NAME}}" planId=<plan> --api-version 7.1 -o json
+
+# cases in a suite
+az devops invoke --area testplan --resource "suite entries" ...   # or resource=TestCase per suite
+```
+`testplan.mjs` wraps the exact resource/route names; adjust `--api-version` per your org if a route
+404s.
+
+## Creating a NEW test case (only on explicit user choice)
+
+```bash
+az boards work-item create --type "Test Case" --title "<title>" \
+  --org {{ORG_URL}} --project "{{PROJECT_NAME}}" \
+  --fields "System.AreaPath={{AREA_PATH}}" -o json
+# then add it to the chosen suite (az devops invoke --area testplan --resource "suite entries" ... PATCH),
+# and link TestedBy to the bug per the user's instruction.
+```
+
+## Failing an existing test case (record a Failed outcome)
+
+A Test Case work item has a **State** (Design/Ready/Closed), not pass/fail — the outcome lives on a
+**Test Point** inside a Plan/Suite. `testplan.mjs fail` (via `az devops invoke --area test`) does:
+
+1. find the test point: iterate the plan's suites → `Suites/{suite}/TestPoint?testCaseId={tc}`.
+2. `POST test/runs` `{name, plan:{id}, pointIds:[point], automated:false, state:"InProgress"}`.
+3. `GET Runs/{run}/results` → resultId; `PATCH`
+   `[{id, outcome:"Failed", state:"Completed", comment, associatedBugs:[{id:bug}]}]`.
+4. `PATCH test/runs/{run}` `{state:"Completed"}`.
+5. Durable link: add `Microsoft.VSTS.Common.TestedBy-Reverse` on the TC → the bug
+   (`az boards work-item relation add --relation-type "tested by" ...`).
+
+Each step is a printed `az devops invoke` command; nothing runs without `--execute`.
+
+## Quick raw read
+
+```bash
+export AZURE_DEVOPS_EXT_PAT=<pat>; export PYTHONIOENCODING=utf-8
+az boards work-item show --id {{TEMPLATE_BUG_ID}} --expand all -o json
+```

--- a/skills/bug-report-azure/scripts/_lib.mjs
+++ b/skills/bug-report-azure/scripts/_lib.mjs
@@ -1,0 +1,172 @@
+// Shared helpers for the report-azure-bug-generic skill.
+//
+// This skill is PRODUCT/TEAM AGNOSTIC. Nothing team-specific is hardcoded: org,
+// project, area path, template id, assignees, environment, etc. are resolved at
+// runtime from (in order) config.json → env vars → `az` configured defaults, and
+// anything still unset is left as a {{PLACEHOLDER}} for the caller to ask about.
+//
+// TOOLING: every Azure interaction goes through the Azure CLI (`az`). There are NO
+// direct REST/API calls here. Reads run freely; writes only run behind --execute and
+// are PRINTED before they run (transparency requirement).
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ---- config / placeholders --------------------------------------------------
+
+// Look for config.json next to the skill, then walk up from cwd (repo root, etc.).
+function findConfigFile() {
+  const candidates = [
+    path.join(__dirname, "..", "config.json"),
+    path.join(__dirname, "..", "config.local.json"),
+  ];
+  let dir = path.resolve(process.cwd());
+  for (let i = 0; i < 8; i++) {
+    candidates.push(path.join(dir, "bug-skill.config.json"));
+    const up = path.dirname(dir);
+    if (up === dir) break;
+    dir = up;
+  }
+  return candidates.find((p) => fs.existsSync(p)) || null;
+}
+
+// Resolve one value: explicit config → env var → az configured default → fallback (may be null).
+export function loadConfig() {
+  const file = findConfigFile();
+  const cfg = file ? JSON.parse(fs.readFileSync(file, "utf8")) : {};
+
+  const org = (cfg.orgUrl || process.env.AZURE_DEVOPS_ORG_URL || "").replace(/\/+$/, "") || null;
+  const project = cfg.project || process.env.AZURE_DEVOPS_DEFAULT_PROJECT || null;
+
+  return {
+    file,
+    org,                                   // {{ORG_URL}}       (may be null → rely on az defaults)
+    project,                               // {{PROJECT_NAME}}  (may be null → rely on az defaults)
+    team: cfg.team || null,                // {{TEAM_NAME}}
+    areaPath: cfg.areaPath || null,        // {{AREA_PATH}}     (else inherit from parent story)
+    iterationPath: cfg.iterationPath || null,
+    templateBugId: cfg.templateBugId || null,   // {{TEMPLATE_BUG_ID}}
+    assignees: Array.isArray(cfg.assignees) ? cfg.assignees : [],
+    valueArea: cfg.valueArea || "Business",
+    environment: cfg.environment || null,  // {{ENVIRONMENT}}  (Custom.Environment; omit if absent)
+    bugCategory: cfg.bugCategory || null,  // {{BUG_CATEGORY}} (Custom.BugCategory; omit if absent)
+    testPlanId: cfg.testPlanId || null,    // {{TEST_PLAN_ID}}
+    apiVersion: cfg.apiVersion || "7.1",
+  };
+}
+
+// Common --org/--project args appended to az calls when config provides them.
+export function orgArgs(cfg) {
+  const a = [];
+  if (cfg.org) a.push("--org", cfg.org);
+  if (cfg.project) a.push("--project", cfg.project);
+  return a;
+}
+
+// ---- az CLI runner ----------------------------------------------------------
+
+// Render an argv array as a copy-pasteable shell command (for transparency logging).
+export function renderCmd(argv) {
+  return argv
+    .map((a) => (/[\s"'$`\\]/.test(a) ? `"${a.replace(/(["\\$`])/g, "\\$1")}"` : a))
+    .join(" ");
+}
+
+// Run an `az ...` command.
+//   opts.write   – true if this mutates the board (create/update/link/attach/outcome)
+//   opts.execute – global execute flag; a write with execute=false is NOT run, only printed
+//   opts.input   – string piped to stdin (used for --in-file "-" style bodies if needed)
+// Reads (write=false) always run. Returns { ran, ok, json, stdout, stderr, status, cmd }.
+export function az(argv, { write = false, execute = false, input } = {}) {
+  const full = ["az", ...argv];
+  const cmd = renderCmd(full);
+
+  if (write && !execute) {
+    // Requirement: log every write command BEFORE it would run; do not run it in dry mode.
+    console.log("  [would run] " + cmd);
+    return { ran: false, ok: true, json: null, stdout: "", stderr: "", status: 0, cmd };
+  }
+  if (write) console.log("  [run] " + cmd);
+
+  const res = spawnSync(full[0], full.slice(1), {
+    input,
+    encoding: "utf8",
+    shell: process.platform === "win32", // az is az.cmd on Windows
+    env: { ...process.env, PYTHONIOENCODING: process.env.PYTHONIOENCODING || "utf-8" },
+    maxBuffer: 32 * 1024 * 1024,
+  });
+
+  if (res.error) {
+    // e.g. az not found — surface the EXACT error, never swallow it.
+    throw new Error(`Failed to launch az: ${res.error.message}\n  cmd: ${cmd}`);
+  }
+  const stdout = res.stdout || "";
+  const stderr = res.stderr || "";
+  if (res.status !== 0) {
+    // Requirement: surface the exact az error to the user; never auto-retry a write.
+    throw new Error(`az exited ${res.status}\n  cmd: ${cmd}\n  stderr:\n${stderr.trim()}`);
+  }
+  let json = null;
+  if (stdout.trim()) { try { json = JSON.parse(stdout); } catch { /* not json */ } }
+  return { ran: true, ok: true, json, stdout, stderr, status: res.status, cmd };
+}
+
+// ---- reusable az operations (reads + write builders) ------------------------
+
+// Read + validate a work item; returns its fields or throws with the exact az error.
+export function showWorkItem(cfg, id, fields) {
+  const argv = ["boards", "work-item", "show", "--id", String(id), ...orgArgs(cfg), "-o", "json"];
+  const r = az(argv);
+  return r.json;
+}
+
+// Idempotency: existing work items of a type with an exact title (WIQL via az boards query).
+export function findByTitle(cfg, type, title) {
+  const safeTitle = String(title).replace(/'/g, "''");
+  const projClause = cfg.project ? ` AND [System.TeamProject]='${cfg.project.replace(/'/g, "''")}'` : "";
+  const wiql =
+    `SELECT [System.Id] FROM workitems WHERE [System.WorkItemType]='${type}'` +
+    projClause + ` AND [System.Title]='${safeTitle}'`;
+  const argv = ["boards", "query", "--wiql", wiql, ...orgArgs(cfg), "-o", "json"];
+  const r = az(argv);
+  const rows = Array.isArray(r.json) ? r.json : (r.json?.workItems || r.json?.value || []);
+  return rows.map((w) => w.id || w.fields?.["System.Id"]).filter(Boolean);
+}
+
+// ---- CLI arg parser: --key value / --key=value / --flag ---------------------
+export function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const eq = a.indexOf("=");
+      if (eq !== -1) {
+        out[a.slice(2, eq)] = a.slice(eq + 1);
+      } else {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("--")) out[a.slice(2)] = true;
+        else { out[a.slice(2)] = next; i++; }
+      }
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+// ---- shared validation tables ----------------------------------------------
+export const VALID_SEVERITY = ["1 - Critical", "2 - High", "3 - Medium", "4 - Low"];
+export const VALID_PRIORITY = [1, 2, 3, 4];
+
+// Recommendation the SKILL workflow shows the user (they still choose). Kept here so the
+// script and the skill text agree. `impact` is a coarse label derived from the run.
+export const IMPACT_RECOMMENDATION = {
+  blocking:    { severity: "1 - Critical", priority: 1, why: "blocks the flow, no workaround" },
+  data:        { severity: "2 - High",     priority: 1, why: "wrong/missing data in an issued artifact" },
+  functional:  { severity: "3 - Medium",   priority: 2, why: "localized functional error, non-blocking" },
+  cosmetic:    { severity: "4 - Low",      priority: 3, why: "minor cosmetic / edge polish" },
+};

--- a/skills/bug-report-azure/scripts/check-image.mjs
+++ b/skills/bug-report-azure/scripts/check-image.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// check-image.mjs — Pass 1 (STRUCTURAL) screenshot validation before a screenshot is
+// attached to an Azure bug. Dependency-free (Node built-ins only). It answers "is this a
+// real, non-blank image?" — NOT "does it show the bug?" (that is the vision pass done by
+// Claude, per SKILL.md step 7). Structural + semantic together = evidence worth attaching.
+//
+// Checks per file:
+//   - is it actually a PNG or JPEG (magic bytes)
+//   - real dimensions (PNG IHDR / JPEG SOF); flags 0x0 (the classic 0x0 dialog capture)
+//   - minimum byte size
+//   - "likely blank" heuristic: for PNG, ratio of compressed IDAT bytes to raw pixel bytes.
+//     A blank/near-uniform capture (white tab, empty page) compresses to almost nothing.
+//
+// Usage:
+//   node check-image.mjs <file> [<file> ...]
+//   node check-image.mjs --dir <folder>          # scan *.png/*.jpg in a folder
+//   node check-image.mjs --json <files...>       # machine-readable JSON array
+//   node check-image.mjs --strict <files...>     # exit 1 if any file is hard-invalid
+//
+// "hard-invalid" = not-an-image | zero-dimension | too-small. "likely-blank" is a WARNING
+// (the human/vision pass decides), not a hard failure.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const MIN_BYTES = 2 * 1024;      // < 2 KB is almost never a real screenshot
+const BLANK_RATIO = 0.0015;      // IDAT/rawPixels below this over a big canvas => suspect blank
+const BLANK_MIN_AREA = 100_000;  // only apply the blank heuristic to reasonably large images
+
+function readChunksPNG(buf) {
+  const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  for (let i = 0; i < 8; i++) if (buf[i] !== sig[i]) return null;
+  let off = 8, width = 0, height = 0, colorType = 0, idatBytes = 0, sawIHDR = false;
+  while (off + 8 <= buf.length) {
+    const len = buf.readUInt32BE(off);
+    const type = buf.toString("ascii", off + 4, off + 8);
+    const dataOff = off + 8;
+    if (type === "IHDR") {
+      width = buf.readUInt32BE(dataOff);
+      height = buf.readUInt32BE(dataOff + 4);
+      colorType = buf[dataOff + 9];
+      sawIHDR = true;
+    } else if (type === "IDAT") {
+      idatBytes += len;
+    } else if (type === "IEND") {
+      break;
+    }
+    off = dataOff + len + 4; // skip data + CRC
+  }
+  if (!sawIHDR) return null;
+  const channels = { 0: 1, 2: 3, 3: 1, 4: 2, 6: 4 }[colorType] ?? 3;
+  return { width, height, channels, idatBytes };
+}
+
+function readDimsJPEG(buf) {
+  if (buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let off = 2;
+  while (off + 9 < buf.length) {
+    if (buf[off] !== 0xff) { off++; continue; }
+    const marker = buf[off + 1];
+    if ((marker >= 0xc0 && marker <= 0xcf) && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      const height = buf.readUInt16BE(off + 5);
+      const width = buf.readUInt16BE(off + 7);
+      return { width, height, channels: 3, idatBytes: 0 };
+    }
+    const segLen = buf.readUInt16BE(off + 2);
+    off += 2 + segLen;
+  }
+  return { width: 0, height: 0, channels: 3, idatBytes: 0 };
+}
+
+function checkFile(file) {
+  const res = { file, ok: false, format: null, width: 0, height: 0, bytes: 0, blankScore: null, issues: [] };
+  if (!fs.existsSync(file)) { res.issues.push("not-found"); return res; }
+  const buf = fs.readFileSync(file);
+  res.bytes = buf.length;
+  let info = null, fmt = null;
+  if (buf.length >= 8 && buf[0] === 0x89 && buf[1] === 0x50) { info = readChunksPNG(buf); fmt = "png"; }
+  else if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8) { info = readDimsJPEG(buf); fmt = "jpeg"; }
+
+  if (!fmt || !info) { res.issues.push("not-an-image"); return res; }
+  res.format = fmt;
+  res.width = info.width; res.height = info.height;
+
+  if (info.width === 0 || info.height === 0) res.issues.push("zero-dimension");
+  if (buf.length < MIN_BYTES) res.issues.push("too-small");
+
+  if (fmt === "png" && info.width * info.height >= BLANK_MIN_AREA) {
+    const raw = info.width * info.height * info.channels;
+    const ratio = raw > 0 ? info.idatBytes / raw : 1;
+    res.blankScore = Number(ratio.toFixed(5));
+    if (ratio < BLANK_RATIO) res.issues.push("likely-blank");
+  }
+
+  const hardInvalid = res.issues.some((i) => ["not-found", "not-an-image", "zero-dimension", "too-small"].includes(i));
+  res.ok = !hardInvalid; // likely-blank is a warning, still "ok" structurally
+  return res;
+}
+
+// ---- CLI --------------------------------------------------------------------
+const argv = process.argv.slice(2);
+const json = argv.includes("--json");
+const strict = argv.includes("--strict");
+let files = argv.filter((a) => !a.startsWith("--"));
+const dirIdx = argv.indexOf("--dir");
+if (dirIdx !== -1 && argv[dirIdx + 1]) {
+  const dir = argv[dirIdx + 1];
+  files = fs.readdirSync(dir)
+    .filter((f) => /\.(png|jpe?g)$/i.test(f))
+    .map((f) => path.join(dir, f));
+}
+if (files.length === 0) { console.error("Usage: check-image.mjs <file...> | --dir <folder>"); process.exit(2); }
+
+const results = files.map(checkFile);
+if (json) {
+  console.log(JSON.stringify(results, null, 2));
+} else {
+  for (const r of results) {
+    const tag = !r.ok ? "INVALID" : r.issues.includes("likely-blank") ? "WARN   " : "OK     ";
+    const dims = r.width && r.height ? `${r.width}x${r.height}` : "?";
+    const extra = r.issues.length ? `  [${r.issues.join(", ")}]` : "";
+    const blank = r.blankScore !== null ? `  blank=${r.blankScore}` : "";
+    console.log(`${tag}  ${dims.padEnd(11)} ${(r.bytes + "b").padEnd(9)}${blank}  ${r.file}${extra}`);
+  }
+}
+if (strict && results.some((r) => !r.ok)) process.exit(1);

--- a/skills/bug-report-azure/scripts/create-bug.mjs
+++ b/skills/bug-report-azure/scripts/create-bug.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+// create-bug.mjs — Create an Azure DevOps Bug that mirrors a configurable team
+// template and link it as a CHILD of a parent User Story. GENERIC / team-agnostic:
+// org, project, area path, assignees, template, custom fields all come from config
+// or the spec — nothing team-specific is hardcoded.
+//
+// TOOLING: everything runs through the Azure CLI (`az boards`, and `az devops invoke`
+// for attachment upload/relations that `az boards` can't do). No direct REST calls.
+//
+// SAFE BY DEFAULT: with no --execute it only prints the PLAN + the exact `az` commands
+// it WOULD run (a dry run). Nothing is written to Azure until --execute is passed. This
+// is the tooling-level enforcement of the skill's single-confirmation gate.
+//
+// Usage:
+//   node create-bug.mjs --spec bug.json            # dry run (plan + idempotency + attachment checks + az cmds)
+//   node create-bug.mjs --spec bug.json --execute  # upload attachments + create bug + parent link
+//   flags: --no-screenshots  create with no evidence (deliberate waiver)
+//          --force           proceed even if an attachment fails the structural check
+//          --allow-duplicate proceed even if a same-title Bug already exists (after user says so)
+//
+// The ONLY link it ever creates is the parent User Story link
+// (az boards work-item relation add --relation-type parent). It never edits the parent
+// story's fields and never touches any test artifact.
+//
+// spec JSON fields — see SKILL.md "Spec JSON shape". Required:
+//   title, severity, priority, parentStoryId, assignedTo, summary, steps, expected, actual
+// Optional: environment, bugCategory, valueArea, areaPath, iterationPath, testConfig,
+//           timestamp, attachments[]
+//
+// Priority and Severity are NOT invented here — they come from the user's choice (SKILL
+// step 4) and the script errors if either is missing or invalid. (Requirement: never
+// infer/auto-fill required fields.)
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  loadConfig, orgArgs, az, parseArgs, showWorkItem, findByTitle,
+  VALID_SEVERITY, VALID_PRIORITY,
+} from "./_lib.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.spec) { console.error("ERROR: --spec <file.json> is required"); process.exit(2); }
+
+const spec = JSON.parse(fs.readFileSync(args.spec, "utf8"));
+const cfg = loadConfig();
+
+// ---- validate spec ----------------------------------------------------------
+const req = ["title", "severity", "priority", "parentStoryId", "assignedTo", "summary", "steps", "expected", "actual"];
+for (const k of req) {
+  if (spec[k] === undefined || spec[k] === null || spec[k] === "")
+    { console.error(`ERROR: spec.${k} is required (do not infer it — ask the user).`); process.exit(2); }
+}
+if (!VALID_SEVERITY.includes(spec.severity)) {
+  console.error(`ERROR: severity must be one of: ${VALID_SEVERITY.join(", ")}`); process.exit(2);
+}
+if (!VALID_PRIORITY.includes(Number(spec.priority))) {
+  console.error(`ERROR: priority must be one of: ${VALID_PRIORITY.join(", ")}`); process.exit(2);
+}
+if (!Array.isArray(spec.steps) || spec.steps.length === 0) {
+  console.error("ERROR: spec.steps must be a non-empty array"); process.exit(2);
+}
+
+const esc = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+// Last-line STRUCTURAL guard on an attachment (valid PNG/JPEG header + non-zero dims + not tiny).
+// The thorough check (blankness + bug-relatedness) lives in check-image.mjs / the vision pass.
+function structuralCheck(file) {
+  if (!fs.existsSync(file)) return { ok: false, reason: "not-found" };
+  const buf = fs.readFileSync(file);
+  if (buf.length < 2 * 1024) return { ok: false, reason: `too-small (${buf.length}b)` };
+  if (buf[0] === 0x89 && buf[1] === 0x50) {
+    const w = buf.readUInt32BE(16), h = buf.readUInt32BE(20);
+    if (!w || !h) return { ok: false, reason: "zero-dimension" };
+    return { ok: true, fmt: "png", w, h };
+  }
+  if (buf[0] === 0xff && buf[1] === 0xd8) return { ok: true, fmt: "jpeg" };
+  return { ok: false, reason: "not-an-image (bad magic)" };
+}
+
+// Build ReproSteps HTML mirroring the template (timestamp+summary / steps / expected /
+// actual + embedded screenshots / test config).
+function buildReproHtml(uploaded) {
+  const ts = spec.timestamp || "";
+  const stepsLi = spec.steps.map((s) => `<li>${esc(s)}</li>`).join("");
+  const imgs = uploaded.map((u) => `<div><img src="${u.url}" alt="${esc(u.name)}"></div>`).join("");
+  return [
+    `<hr style="border-color:black;">`,
+    `<table><tbody><tr>`,
+    `<td style="vertical-align:top;padding:2px 7px;font-weight:bold;">${esc(ts)}</td>`,
+    `<td style="vertical-align:top;padding:2px 7px 2px 10px;">${esc(spec.summary)}</td>`,
+    `</tr></tbody></table>`,
+    `<hr style="border-color:black;">`,
+    `<table><tbody>`,
+    `<tr><td style="vertical-align:top;padding:2px 7px;font-weight:bold;">Steps:</td></tr>`,
+    `<tr><td style="vertical-align:top;padding:2px 7px;"><ol>${stepsLi}</ol></td></tr>`,
+    `<tr><td style="vertical-align:top;padding:2px 7px;">`,
+    `<div style="padding-top:10px;text-decoration:underline;">Expected Result</div>`,
+    `<div>${esc(spec.expected)}</div>`,
+    `<div><br></div>`,
+    `<div style="text-decoration:underline;">Actual Result</div>`,
+    `<div>${esc(spec.actual)}</div>`,
+    imgs,
+    `</td></tr>`,
+    `</tbody></table>`,
+    `<hr style="border-color:white;">`,
+    `<table><tbody><tr>`,
+    `<td style="vertical-align:top;padding:2px 7px;font-weight:bold;">Test Configuration:</td>`,
+    `<td style="vertical-align:top;padding:2px 7px 2px 100px;">${esc(spec.testConfig || "Windows 11 / Chrome")}</td>`,
+    `</tr></tbody></table>`,
+  ].join("");
+}
+
+// Upload one attachment via `az devops invoke` (az boards has no attachment verb) → {id,url}.
+function uploadAttachment(cfg, filePath, execute) {
+  const name = path.basename(filePath);
+  const argv = [
+    "devops", "invoke",
+    "--area", "wit", "--resource", "attachments",
+    "--http-method", "POST",
+    "--route-parameters", `project=${cfg.project || ""}`,
+    "--query-parameters", `fileName=${name}`,
+    "--in-file", filePath,
+    "--api-version", cfg.apiVersion,
+    ...(cfg.org ? ["--org", cfg.org] : []),
+    "-o", "json",
+  ];
+  const r = az(argv, { write: true, execute });
+  if (!r.ran) return { name, id: "<dry-run>", url: "<dry-run-attachment-url>" };
+  return { name, id: r.json?.id, url: r.json?.url };
+}
+
+// ---- main -------------------------------------------------------------------
+(async () => {
+  // 1) validate + inherit from parent story (READ)
+  const parent = showWorkItem(cfg, spec.parentStoryId);
+  const pf = parent?.fields || {};
+  if (pf["System.WorkItemType"] !== "User Story") {
+    console.error(`ERROR: parent #${spec.parentStoryId} is a "${pf["System.WorkItemType"] || "?"}", not a User Story. `
+      + `Per skill constraints a Bug may only be a child of a User Story.`);
+    process.exit(2);
+  }
+  const areaPath = spec.areaPath || cfg.areaPath || pf["System.AreaPath"];
+  const iterationPath = spec.iterationPath || cfg.iterationPath || pf["System.IterationPath"];
+
+  // 2) idempotency check (READ) — same-title Bug already on the board?
+  let dupes = [];
+  try { dupes = findByTitle(cfg, "Bug", spec.title); } catch (e) {
+    console.log("(idempotency check skipped — query failed:", e.message.split("\n")[0], ")");
+  }
+
+  console.log("=== PLAN (Bug create) ===");
+  console.log("Org / Project :", cfg.org || "(az default)", "/", cfg.project || "(az default)");
+  console.log("Title         :", spec.title);
+  console.log("Parent story  :", `#${spec.parentStoryId}  "${pf["System.Title"]}"  [${pf["System.State"]}]`);
+  console.log("Link type     : parent (System.LinkTypes.Hierarchy-Reverse)  [ONLY link created]");
+  console.log("Assigned to   :", spec.assignedTo);
+  console.log("Priority      :", spec.priority, " (from user choice)");
+  console.log("Severity      :", spec.severity, " (from user choice)");
+  console.log("Area Path     :", areaPath, spec.areaPath ? "" : "(inherited/config)");
+  console.log("Iteration     :", iterationPath, spec.iterationPath ? "" : "(inherited/config)");
+  if (spec.environment || cfg.environment) console.log("Environment   :", spec.environment || cfg.environment);
+  if (spec.bugCategory || cfg.bugCategory) console.log("Bug Category  :", spec.bugCategory || cfg.bugCategory);
+  console.log("Value Area    :", spec.valueArea || cfg.valueArea);
+  console.log("Attachments   :", (spec.attachments || []).join(", ") || "(none)");
+  console.log("\n--- Repro (rendered text) ---");
+  console.log(spec.timestamp ? `[${spec.timestamp}] ${spec.summary}` : spec.summary);
+  console.log("Steps:"); spec.steps.forEach((s, i) => console.log(`  ${i + 1}. ${s}`));
+  console.log("Expected Result:", spec.expected);
+  console.log("Actual Result  :", spec.actual);
+
+  if (dupes.length) {
+    console.log(`\n⚠ IDEMPOTENCY: ${dupes.length} existing Bug(s) with this exact title: #${dupes.join(", #")}`);
+    if (args.execute && !args["allow-duplicate"]) {
+      console.error("REFUSING to create a possible duplicate. Confirm with the user, then pass --allow-duplicate.");
+      process.exit(2);
+    }
+  }
+
+  // 3) attachment structural checks (dry run included)
+  const atts = spec.attachments || [];
+  const badAtts = [];
+  for (const a of atts) {
+    const c = structuralCheck(a);
+    const dim = c.w ? `${c.w}x${c.h}` : (c.fmt || "");
+    console.log(`  attachment: ${a} -> ${c.ok ? "OK " + dim : "INVALID (" + c.reason + ")"}`);
+    if (!c.ok) badAtts.push(a);
+  }
+  if (badAtts.length && !args.force) {
+    console.error(`\nERROR: ${badAtts.length} attachment(s) failed the structural check. `
+      + `Fix or drop them (run check-image.mjs + the vision pass), or pass --force to override.`);
+    process.exit(2);
+  }
+  if (atts.length === 0) {
+    console.log("\n⚠ No screenshots attached. Bugs should include evidence — validate & attach some.");
+    if (args.execute && !args["no-screenshots"]) {
+      console.error("REFUSING to create an evidence-less bug. Pass --no-screenshots to do it deliberately.");
+      process.exit(2);
+    }
+  }
+
+  // 4) show the exact az write commands (transparency), always — dry or execute.
+  console.log("\n--- az write commands ---");
+
+  if (!args.execute) {
+    // Print representative commands without running them.
+    uploadAttachment(cfg, "<each attachment>", false);
+    az(["boards", "work-item", "create", "--type", "Bug", "--title", spec.title, ...orgArgs(cfg),
+        "--fields", "System.AreaPath=" + areaPath, "…(+ severity/priority/assignedTo/repro)"],
+       { write: true, execute: false });
+    az(["boards", "work-item", "relation", "add", "--id", "<newBugId>",
+        "--relation-type", "parent", "--target-id", String(spec.parentStoryId), ...orgArgs(cfg)],
+       { write: true, execute: false });
+    console.log("\nDRY RUN — nothing written. Re-run with --execute after the user confirms the summary.");
+    return;
+  }
+
+  // ---- WRITE PATH (only past explicit --execute) ----
+  const uploaded = [];
+  for (const a of atts) uploaded.push(uploadAttachment(cfg, a, true));
+
+  // Assemble --fields. Custom.* only when a value exists (stock processes won't have them).
+  const fields = [
+    `System.AreaPath=${areaPath}`,
+    `System.IterationPath=${iterationPath}`,
+    `System.AssignedTo=${spec.assignedTo}`,
+    `Microsoft.VSTS.Common.Priority=${Number(spec.priority)}`,
+    `Microsoft.VSTS.Common.Severity=${spec.severity}`,
+    `Microsoft.VSTS.Common.ValueArea=${spec.valueArea || cfg.valueArea}`,
+    `Microsoft.VSTS.TCM.ReproSteps=${buildReproHtml(uploaded)}`,
+  ];
+  const envVal = spec.environment || cfg.environment;
+  const catVal = spec.bugCategory || cfg.bugCategory;
+  if (envVal) fields.push(`Custom.Environment=${envVal}`);
+  if (catVal) fields.push(`Custom.BugCategory=${catVal}`);
+
+  const createArgv = ["boards", "work-item", "create", "--type", "Bug", "--title", spec.title,
+    ...orgArgs(cfg)];
+  for (const f of fields) createArgv.push("--fields", f);
+  createArgv.push("-o", "json");
+
+  const created = az(createArgv, { write: true, execute: true });
+  const id = created.json?.id;
+  if (!id) { console.error("FAILED: could not read new work item id from az output."); process.exit(1); }
+
+  // parent link (the ONLY relation)
+  az(["boards", "work-item", "relation", "add", "--id", String(id),
+      "--relation-type", "parent", "--target-id", String(spec.parentStoryId),
+      ...orgArgs(cfg), "-o", "json"], { write: true, execute: true });
+
+  // attach each uploaded file as an AttachedFile relation via az devops invoke PATCH
+  for (const u of uploaded) {
+    const patch = [{ op: "add", path: "/relations/-",
+      value: { rel: "AttachedFile", url: u.url, attributes: { comment: u.name } } }];
+    const tmp = path.join(os.tmpdir(), `attach-${id}-${u.name}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(patch));
+    az(["devops", "invoke", "--area", "wit", "--resource", "workitems",
+        "--route-parameters", `id=${id}`, "--http-method", "PATCH",
+        "--api-version", cfg.apiVersion, "--in-file", tmp,
+        ...(cfg.org ? ["--org", cfg.org] : []), "-o", "json"], { write: true, execute: true });
+    fs.rmSync(tmp, { force: true });
+  }
+
+  const webUrl = cfg.org
+    ? `${cfg.org}/${encodeURIComponent(cfg.project || "")}/_workitems/edit/${id}`
+    : `(open work item #${id} in your org)`;
+  console.log(`\n✅ Created Bug #${id}`);
+  console.log("   ", webUrl);
+  console.log(`   Parent: #${spec.parentStoryId}  |  Severity: ${spec.severity}  |  Priority: ${spec.priority}`);
+  console.log("BUG_ID=" + id); // machine-readable line for the caller
+})().catch((e) => { console.error("\nFAILED:", e.message); process.exit(1); });

--- a/skills/bug-report-azure/scripts/testplan.mjs
+++ b/skills/bug-report-azure/scripts/testplan.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+// testplan.mjs — read test plans/suites, find/validate a test case, create a new test
+// case (only on explicit user choice), and record a Failed outcome for an existing test
+// case associated with a bug. GENERIC / team-agnostic (plan/suite/case ids are passed in).
+//
+// TOOLING: everything runs through the Azure CLI. `az boards work-item` covers work-item
+// reads and test-case creation; test-plan/point/run routes go through `az devops invoke`
+// (`az boards` has no native verb for them). No direct REST calls.
+//
+// This script NEVER edits a test case's fields, never edits a plan/suite, and only writes
+// in two explicit, user-chosen, --execute-gated ways:
+//   (a) create-case : create a Test Case + add it to a suite (user asked for a NEW case)
+//   (b) fail        : record a Failed test *result* on a test point + link TC->bug
+//
+// Subcommands:
+//   list-suites  --plan <id>
+//   list-cases   --plan <id> [--suite <id>]                 # read only
+//   find-case    --plan <id> --testcase <id>                # validate exists + locate point (read only)
+//   create-case  --plan <id> --suite <id> --title "..." [--area "..."] [--execute]
+//   fail         --plan <id> --testcase <id> --bug <id> [--comment "..."] [--run-name "..."] [--execute]
+//
+// Auth/config come from `az` + config.json via _lib.mjs.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadConfig, orgArgs, az, parseArgs, showWorkItem, findByTitle } from "./_lib.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const cmd = args._[0];
+const cfg = loadConfig();
+const API = cfg.apiVersion;
+
+const need = (k) => { if (!args[k]) { console.error(`ERROR: --${k} is required`); process.exit(2); } return args[k]; };
+const orgFlag = cfg.org ? ["--org", cfg.org] : [];
+
+// --- read helpers (via az devops invoke --area testplan) ---------------------
+function listSuites(plan) {
+  const r = az(["devops", "invoke", "--area", "testplan", "--resource", "suites",
+    "--route-parameters", `project=${cfg.project || ""}`, `planId=${plan}`,
+    "--api-version", API, ...orgFlag, "-o", "json"]);
+  return r.json?.value || r.json || [];
+}
+
+function casesInSuite(plan, suite) {
+  const r = az(["devops", "invoke", "--area", "testplan", "--resource", "test cases",
+    "--route-parameters", `project=${cfg.project || ""}`, `planId=${plan}`, `suiteId=${suite}`,
+    "--api-version", API, ...orgFlag, "-o", "json"]);
+  return r.json?.value || [];
+}
+
+function pointForCase(plan, suite, testcase) {
+  // Per-suite TestPoint lookup; the global ?testCaseId shortcut 404s on many orgs.
+  try {
+    const r = az(["devops", "invoke", "--area", "testplan", "--resource", "test point",
+      "--route-parameters", `project=${cfg.project || ""}`, `planId=${plan}`, `suiteId=${suite}`,
+      "--query-parameters", `testCaseId=${testcase}`, "--api-version", API, ...orgFlag, "-o", "json"]);
+    return (r.json?.value || [])[0] || null;
+  } catch { return null; }
+}
+
+function findPoint(plan, testcase) {
+  for (const s of listSuites(plan)) {
+    const pt = pointForCase(plan, s.id, testcase);
+    if (pt) return { suite: s, point: pt };
+  }
+  return null;
+}
+
+(async () => {
+  if (cmd === "list-suites") {
+    const plan = need("plan");
+    const suites = listSuites(plan);
+    console.log(`Suites in plan ${plan}:`);
+    for (const s of suites) console.log(`  suite ${s.id}  ${s.name}  (${s.suiteType || ""})`);
+    return;
+  }
+
+  if (cmd === "list-cases") {
+    const plan = need("plan");
+    const suites = args.suite ? [{ id: args.suite, name: "(given)" }] : listSuites(plan);
+    for (const s of suites) {
+      let cases = [];
+      try { cases = casesInSuite(plan, s.id); } catch { continue; }
+      if (!cases.length) continue;
+      console.log(`\nSuite ${s.id}  ${s.name}:`);
+      for (const c of cases) {
+        const wi = c.workItem || c;
+        console.log(`  TC ${wi.id}  ${wi.name || wi.fields?.["System.Title"] || ""}`);
+      }
+    }
+    return;
+  }
+
+  if (cmd === "find-case") {
+    // Validate the TC exists as a Test Case work item, then locate its point in the plan.
+    const plan = need("plan"); const tc = need("testcase");
+    let wi;
+    try { wi = showWorkItem(cfg, tc); } catch (e) {
+      console.error(`ERROR: test case #${tc} not found via az.\n${e.message}`); process.exit(1);
+    }
+    const type = wi?.fields?.["System.WorkItemType"];
+    if (type !== "Test Case") {
+      console.error(`ERROR: #${tc} is a "${type}", not a Test Case. Ask the user for a valid test case id.`);
+      process.exit(1);
+    }
+    console.log(`TC #${tc} exists: "${wi.fields["System.Title"]}" [${wi.fields["System.State"]}]`);
+    const hit = findPoint(plan, tc);
+    if (!hit) { console.log(`(no test point for TC ${tc} in plan ${plan} — it may not be assigned to a suite there)`); process.exit(0); }
+    console.log(`TC ${tc} -> plan ${plan} / suite ${hit.suite.id} (${hit.suite.name}) / point ${hit.point.id}`);
+    return;
+  }
+
+  if (cmd === "create-case") {
+    // Only on the user's explicit "create a new test case" choice.
+    const plan = need("plan"); const suite = need("suite"); const title = need("title");
+    const area = args.area || cfg.areaPath || null;
+
+    // idempotency: an identically-titled Test Case already there?
+    let dupes = [];
+    try { dupes = findByTitle(cfg, "Test Case", title); } catch { /* non-fatal */ }
+
+    console.log("=== PLAN (create test case) ===");
+    console.log("Title :", title);
+    console.log("Plan  :", plan, " Suite:", suite);
+    console.log("Area  :", area || "(project default)");
+    if (dupes.length) {
+      console.log(`⚠ IDEMPOTENCY: existing Test Case(s) with this title: #${dupes.join(", #")}`);
+      if (args.execute && !args["allow-duplicate"]) {
+        console.error("REFUSING possible duplicate. Confirm with the user, then pass --allow-duplicate.");
+        process.exit(2);
+      }
+    }
+
+    const createArgv = ["boards", "work-item", "create", "--type", "Test Case", "--title", title, ...orgArgs(cfg)];
+    if (area) { createArgv.push("--fields", `System.AreaPath=${area}`); }
+    createArgv.push("-o", "json");
+
+    if (!args.execute) {
+      console.log("\n--- az write commands ---");
+      az(createArgv, { write: true, execute: false });
+      az(["devops", "invoke", "--area", "testplan", "--resource", "suite entries",
+        "--route-parameters", `project=${cfg.project || ""}`, `suiteId=${suite}`,
+        "--http-method", "PATCH", "--api-version", API, "--in-file", "<[{ \"id\": <newTcId> }]>",
+        ...orgFlag], { write: true, execute: false });
+      console.log("\nDRY RUN — nothing written. Re-run with --execute after user confirms.");
+      return;
+    }
+
+    console.log("\n--- az write commands ---");
+    const created = az(createArgv, { write: true, execute: true });
+    const tcId = created.json?.id;
+    if (!tcId) { console.error("FAILED: could not read new test case id."); process.exit(1); }
+
+    // add to the suite
+    const tmp = path.join(os.tmpdir(), `suite-add-${tcId}.json`);
+    fs.writeFileSync(tmp, JSON.stringify([{ id: Number(tcId) }]));
+    az(["devops", "invoke", "--area", "testplan", "--resource", "suite entries",
+      "--route-parameters", `project=${cfg.project || ""}`, `suiteId=${suite}`,
+      "--http-method", "PATCH", "--api-version", API, "--in-file", tmp, ...orgFlag, "-o", "json"],
+      { write: true, execute: true });
+    fs.rmSync(tmp, { force: true });
+
+    console.log(`\n✅ Created Test Case #${tcId} and added it to suite ${suite}.`);
+    console.log("TC_ID=" + tcId);
+    return;
+  }
+
+  if (cmd === "fail") {
+    const plan = need("plan"); const tc = need("testcase"); const bug = need("bug");
+    const comment = args.comment || `Failed during automated regression run; see Bug #${bug}.`;
+    const hit = findPoint(plan, tc);
+    if (!hit) {
+      console.error(`ERROR: no test point for TC ${tc} in plan ${plan}; cannot record a Failed result.`);
+      process.exit(1);
+    }
+    console.log("=== PLAN (fail existing test case) ===");
+    console.log(`TC ${tc} -> plan ${plan} / suite ${hit.suite.id} / point ${hit.point.id}`);
+    console.log(`Outcome    : Failed`);
+    console.log(`Bug link   : associatedBugs=[#${bug}]  +  TC->bug "tested by" work-item link`);
+    console.log(`Comment    : ${comment}`);
+
+    const runBody = { name: args["run-name"] || `Regression fail — TC ${tc} (Bug ${bug})`,
+      plan: { id: String(plan) }, pointIds: [Number(hit.point.id)], automated: false, state: "InProgress" };
+
+    if (!args.execute) {
+      console.log("\n--- az write commands ---");
+      az(["devops", "invoke", "--area", "test", "--resource", "runs", "--http-method", "POST",
+        "--route-parameters", `project=${cfg.project || ""}`, "--api-version", API,
+        "--in-file", `<${JSON.stringify(runBody)}>`, ...orgFlag], { write: true, execute: false });
+      az(["devops", "invoke", "--area", "test", "--resource", "results", "--http-method", "PATCH",
+        "--route-parameters", `project=${cfg.project || ""}`, "runId=<runId>", "--api-version", API,
+        "--in-file", "<[{id,outcome:Failed,state:Completed,associatedBugs:[{id:bug}]}]>", ...orgFlag],
+        { write: true, execute: false });
+      az(["boards", "work-item", "relation", "add", "--id", String(tc), "--relation-type", "tested by",
+        "--target-id", String(bug), ...orgArgs(cfg)], { write: true, execute: false });
+      console.log("\nDRY RUN — nothing written. Re-run with --execute after user confirms.");
+      return;
+    }
+
+    console.log("\n--- az write commands ---");
+    // 1) create a manual run over the point
+    let tmp = path.join(os.tmpdir(), `run-${tc}.json`);
+    fs.writeFileSync(tmp, JSON.stringify(runBody));
+    const run = az(["devops", "invoke", "--area", "test", "--resource", "runs", "--http-method", "POST",
+      "--route-parameters", `project=${cfg.project || ""}`, "--api-version", API,
+      "--in-file", tmp, ...orgFlag, "-o", "json"], { write: true, execute: true });
+    fs.rmSync(tmp, { force: true });
+    const runId = run.json?.id;
+
+    // 2) read the result id, then PATCH it to Failed + associate the bug
+    const results = az(["devops", "invoke", "--area", "test", "--resource", "results",
+      "--route-parameters", `project=${cfg.project || ""}`, `runId=${runId}`,
+      "--api-version", API, ...orgFlag, "-o", "json"]);
+    const rid = results.json?.value?.[0]?.id || 100000;
+    tmp = path.join(os.tmpdir(), `result-${tc}.json`);
+    fs.writeFileSync(tmp, JSON.stringify([{ id: rid, outcome: "Failed", state: "Completed",
+      comment, associatedBugs: [{ id: String(bug) }] }]));
+    az(["devops", "invoke", "--area", "test", "--resource", "results", "--http-method", "PATCH",
+      "--route-parameters", `project=${cfg.project || ""}`, `runId=${runId}`, "--api-version", API,
+      "--in-file", tmp, ...orgFlag, "-o", "json"], { write: true, execute: true });
+    fs.rmSync(tmp, { force: true });
+
+    // 3) complete the run
+    tmp = path.join(os.tmpdir(), `run-complete-${tc}.json`);
+    fs.writeFileSync(tmp, JSON.stringify({ state: "Completed" }));
+    az(["devops", "invoke", "--area", "test", "--resource", "runs", "--http-method", "PATCH",
+      "--route-parameters", `project=${cfg.project || ""}`, `runId=${runId}`, "--api-version", API,
+      "--in-file", tmp, ...orgFlag, "-o", "json"], { write: true, execute: true });
+    fs.rmSync(tmp, { force: true });
+
+    // 4) durable work-item link TC -> bug ("tested by" == TestedBy-Reverse on the TC)
+    az(["boards", "work-item", "relation", "add", "--id", String(tc), "--relation-type", "tested by",
+      "--target-id", String(bug), ...orgArgs(cfg), "-o", "json"], { write: true, execute: true });
+
+    console.log(`\n✅ Recorded Failed result for TC ${tc} (run ${runId}, result ${rid}); linked to Bug #${bug}.`);
+    return;
+  }
+
+  console.error("Usage: testplan.mjs <list-suites|list-cases|find-case|create-case|fail> [options]");
+  process.exit(2);
+})().catch((e) => { console.error("\nFAILED:", e.message); process.exit(1); });


### PR DESCRIPTION
- **Not tied to any team** — org, project, assignees, etc. come from a `config.json` you fill in (copy `config.example.json` to start).
- **Asks before it acts** — you confirm all the details in one summary before any bug is created.
- **Safe by default** — the helper scripts show you the exact commands first and only run them when you add `--execute`.
 
Includes the skill definition (`SKILL.md`), helper scripts, an Azure DevOps reference, and an example config.