### PR TITLE
Add Jira integration skill and wire it into task-estimation/test-design

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agentex",
   "displayName": "AgenTeX",
   "version": "0.7.0",
-  "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli. Test steps can call your APIs and query your database from a user-defined integration catalog. On Azure DevOps it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
+  "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli. Test steps can call your APIs and query your database from a user-defined integration catalog. On Azure DevOps or jira it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
   "author": {
     "name": "Mohamed Elgazzar",
     "email": "mhmd.elgazzar.sqe@gmail.com"

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,17 @@ AZURE_ASSIGNEE=qa.engineer@example.com
 # AZURE_DEVOPS_EXT_PAT — export it in your shell (the agent never prints or passes the PAT):
 #   export AZURE_DEVOPS_EXT_PAT="$AZURE_PAT"
 AZURE_PAT=
+
+
+# ─── Jira ──────────────────────────────────────────────────────────────────────
+# Used by the jira-integration skill (acli).
+JIRA_URL=https://your-domain.atlassian.net
+JIRA_EMAIL=qa.engineer@example.com
+JIRA_PROJECT=your-project-key
+JIRA_BOARD_ID=
+JIRA_ASSIGNEE=qa.engineer@example.com
+# API token for non-interactive auth (create at
+# https://id.atlassian.com/manage-profile/security/api-tokens). The agent never prints or
+# passes it on the command line — `acli` reads it from JIRA_API_TOKEN.
+JIRA_API_TOKEN=
+

--- a/skills/jira-integration/SKILL.md
+++ b/skills/jira-integration/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: jira-integration
+description: Interact with Jira from a QA/test run via the Atlassian CLI (`acli`) — auth, discovery, and reading/creating/linking issues. Use whenever a task needs to reach Jira (fetch a sprint's stories, inspect an issue's description/ACs, create or link an issue) or when `acli` is not installed. Read the reference before the first `acli` command.
+---
+
+# Jira Integration
+
+## Role
+You connect a test run to Jira through the Atlassian CLI (`acli`, run via Bash).
+You use Jira to **support** testing — reading issues, fetching sprint/board contents, and
+creating/linking issues (tasks, test cases) — not to reconfigure projects, workflows, or
+permissions. Prefer read-only commands; get explicit confirmation before any create/update/delete.
+
+## Tool
+Setup, install, auth, and common commands live in this skill's `references/` folder. **Read the
+reference file BEFORE the first `acli` command in a session**, and again whenever a command
+behaves unexpectedly:
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/jira-cli.md`** — Atlassian CLI
+  (`acli`): install-if-missing (winget/brew/apt/manual), auth (API token, site URL), and
+  common commands for projects/boards/sprints.
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/jira-issues-cli.md`** — issue
+  mechanics (`acli jira workitem ...`): JQL search, sprint/current-iteration fetch, issue
+  create/show/link, comments, transitions. Shared by any skill that needs to read or write
+  Jira issues (analogous to task-estimation/test-design's use of `az boards`).
+
+## Rules
+- Preflight `acli --version` before use; install per the reference if it's missing.
+- **Never print or log secrets** — API tokens, account IDs in bulk, webhook secrets. Do not
+  echo `--token` values.
+- Default to read-only (`workitem search`, `workitem view`). Confirm with the user before any
+  command that creates, updates, transitions, or deletes an issue.
+- In CI/non-interactive shells, authenticate via API token from env vars — never hardcode
+  credentials.

--- a/skills/jira-integration/references/jira-cli.md
+++ b/skills/jira-integration/references/jira-cli.md
@@ -1,0 +1,42 @@
+# Tool: Atlassian CLI (`acli`)
+
+Atlassian's official command-line tool for Jira (and Confluence/Compass). Read this when a task
+needs Jira data (projects, boards, sprints, issues) or when `acli` is missing.
+
+## Preflight & install
+- Preflight: `acli --version` (verify it's installed and check the version).
+- If missing, install:
+  - **Windows (preferred):** `winget install -e --id Atlassian.acli`
+    - Or download the binary from https://developer.atlassian.com/cloud/acli/ and add it to PATH.
+  - **macOS:** `brew tap atlassian/acli && brew install acli`
+  - **Linux (Debian/Ubuntu):** download the `.deb` from the Atlassian CLI releases page and
+    `sudo dpkg -i acli_*.deb`
+- After install, open a new shell so `acli` is on PATH.
+- Upgrade later with the same install command (or `acli update` if supported by your version).
+
+## Auth (never put a token on the command line)
+- API token: create one at https://id.atlassian.com/manage-profile/security/api-tokens
+- Login (stores credentials in the local config, not passed as flags):
+  `acli jira auth login --site "$JIRA_URL" --email "$JIRA_EMAIL"` — prompts for the token, or
+  reads it from the `JIRA_API_TOKEN` env var if set.
+- Non-interactive / CI: export `JIRA_API_TOKEN` (and `JIRA_EMAIL`, `JIRA_URL`) in the shell —
+  never hardcode or print it. Do NOT pass `--token` as a literal flag value in a logged command.
+- `acli jira auth status` — verify the current session/site.
+- `acli jira auth logout` — clear stored credentials.
+
+## Common usage
+- **Config / discovery**
+  - `acli jira project list` — list projects
+  - `acli jira project view --key <PROJ>` — project details
+  - `acli jira board list --project <PROJ>` — boards for a project
+  - `acli jira sprint list --board <BOARD_ID>` — sprints on a board (use `--state active` for
+    the current sprint)
+- **Generic**
+  - `acli jira <group> <cmd> --help` — built-in help
+  - Add `--json` to most commands for machine-readable output; pipe to a JSON tool to filter.
+
+## Notes
+- `acli` is a standalone binary — install via winget/brew/package manager, not `npm install`.
+- Treat API tokens and account IDs as sensitive — never print them to logs.
+- Issue (work item) read/write mechanics — JQL search, create, link, comment, transition — live
+  in the sibling reference `jira-issues-cli.md`.

--- a/skills/jira-integration/references/jira-issues-cli.md
+++ b/skills/jira-integration/references/jira-issues-cli.md
@@ -1,0 +1,69 @@
+# Tool: Atlassian CLI issue commands (`acli jira workitem`)
+
+Issue (work item) mechanics for the Atlassian CLI. Read this before the first
+`acli jira workitem` command in a session, or when one behaves unexpectedly. For installing/
+authenticating `acli` itself, see the sibling reference `jira-cli.md`.
+
+## Preflight
+- `acli jira auth status` — confirm you're authenticated against the right site.
+
+## Current sprint (fetch dynamically — never hardcode)
+```bash
+SPRINT_ID=$(acli jira sprint list --board "$JIRA_BOARD_ID" --state active --json \
+  | jq -r '.[0].id')
+echo "$SPRINT_ID"
+```
+
+## Fetch sprint issues (JQL)
+```bash
+acli jira workitem search --jql "project = $JIRA_PROJECT AND sprint = $SPRINT_ID AND issuetype = Story ORDER BY key" \
+  --json
+```
+> JQL is the Jira equivalent of ADO's WIQL — filter by `project`, `sprint`, `issuetype`,
+> `status`, etc.
+
+## Inspect an issue
+```bash
+acli jira workitem view --key <PROJ-123> --json     # description + ACs to analyze
+```
+
+## Check for existing linked issues (before creating)
+```bash
+acli jira workitem view --key <PROJ-123> --json | jq '.fields.issuelinks'
+```
+If linked sub-tasks/issues already exist, tell the user and ask whether to skip or add more.
+
+## Create an issue + link to parent
+```bash
+NEW_KEY=$(acli jira workitem create --project "$JIRA_PROJECT" --type "Task" \
+  --summary "[Testing] Test Creation" \
+  --assignee "$JIRA_ASSIGNEE" \
+  --json | jq -r '.key')
+
+# Link to parent (subtask) or relate two issues
+acli jira workitem link --key "$NEW_KEY" --link-type "relates to" --target-key <PROJ-123>
+```
+> For a true parent/child (sub-task) relationship, create with `--type "Sub-task" --parent <PROJ-123>`
+> instead of a generic link.
+
+## Comment
+```bash
+acli jira workitem comment add --key <PROJ-123> --body "Verified in build 1.4.2"
+```
+
+## Transition (status change)
+```bash
+acli jira workitem transition list --key <PROJ-123>      # see available transitions
+acli jira workitem transition --key <PROJ-123> --status "In Progress"
+```
+
+## Delete (destructive — confirm first)
+```bash
+acli jira workitem delete --key <PROJ-123>
+```
+
+## Notes
+- Add `--json` to most commands for machine-readable output; pipe to `jq` to filter/extract.
+- Mandatory fields at a glance for a new issue: `--project`, `--type`, `--summary`,
+  `--assignee` (if the project requires one), plus `--parent` for sub-tasks.
+- Issue keys (`PROJ-123`) are the Jira equivalent of ADO work-item IDs.

--- a/skills/task-estimation/SKILL.md
+++ b/skills/task-estimation/SKILL.md
@@ -132,3 +132,34 @@ Bot: Story #12345 — Capture Contact Preferences (3 SP)
 User: تمام
 Bot: [creates 5 tasks — iteration inherited, Activity: Testing, assigned] ✅ Done. Next: #12346...
 ```
+## Jira (in addition to Azure DevOps)
+
+This skill also works on **Jira** — everything above (task template, estimation factors,
+complexity buckets, hours-per-task, workflow, rules) applies unchanged. Only the tracker
+mechanics differ.
+
+- **Detect the tracker**: a pasted link (`dev.azure.com/...` → Azure DevOps,
+  `*.atlassian.net/...` → Jira), what the user names explicitly, or — if ambiguous — ask once
+  and reuse the answer for the session.
+- **Reference**: read
+  `${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/jira-issues-cli.md` before the
+  first `acli jira workitem` command. Base `acli` install/auth is in the sibling
+  **jira-integration** skill's `references/jira-cli.md`.
+- **Configuration (Jira)**: `JIRA_URL`, `JIRA_PROJECT`, `JIRA_BOARD_ID`, `JIRA_ASSIGNEE` /
+  ask once each; `JIRA_API_TOKEN` env in the user's shell — never print or pass it (see
+  `.env.example`).
+- **Field mapping** for the same 5-task template:
+
+  | ADO field | Jira equivalent |
+  |---|---|
+  | `--type Task` | `--type "Sub-task"` (or `Task` + a link, if the story's issue type disallows sub-tasks) |
+  | `--title "[Testing] <name>"` | `--summary "[Testing] <name>"` |
+  | `--iteration <parent story's iteration>` | `--parent <STORY_KEY>` |
+  | `--assigned-to <assignee>` | `--assignee <assignee>` |
+  | `Microsoft.VSTS.Common.Activity=Testing` | label `testing` (Jira has no Activity field) |
+  | `OriginalEstimate`/`RemainingWork` | timetracking `originalEstimate`/`remainingEstimate` |
+
+- **Sprint fetch / current iteration**: use JQL against the active sprint (see the reference)
+  instead of WIQL `@CurrentIteration`.
+- Everything else — one story at a time, show-then-confirm before creating, never batch —
+  applies exactly as written above for ADO.

--- a/skills/test-design/SKILL.md
+++ b/skills/test-design/SKILL.md
@@ -172,3 +172,32 @@ ask whether to add a test case for it.
 - ❌ Creating input test cases when the story has no input fields
 - ❌ Skipping non-primary-language text checks when the project is multilingual
 - ❌ Using a feature that doesn't match the feature map
+
+## Jira (in addition to Azure DevOps)
+
+This skill also works on **Jira** — the whole methodology above (condition mapping, title
+convention, step derivation, coverage check, common mistakes) applies unchanged. Only the
+Test Case creation/linking mechanics differ.
+
+- **Detect the tracker**: a pasted link (`dev.azure.com/...` → Azure DevOps,
+  `*.atlassian.net/...` → Jira), what the user names explicitly, or — if ambiguous — ask once
+  and reuse the answer for the session.
+- **Reference**: read
+  `${CLAUDE_PLUGIN_ROOT}/skills/test-design/references/jira-test-case-mechanics.md` before
+  creating or linking any Jira test case, plus the jira-integration skill's
+  `references/jira-issues-cli.md` for shared `acli` basics.
+- **Configuration (Jira)**: `JIRA_URL`, `JIRA_PROJECT`, `JIRA_BOARD_ID`, `JIRA_ASSIGNEE` /
+  ask once each; `JIRA_API_TOKEN` env in the user's shell — never print or pass it. Additionally
+  ask once (no ADO equivalent):
+  - **Test Case issue type name** — Jira has no built-in Test Case type; it's usually a
+    plugin's type (Xray: `Test`, Zephyr: `Test Case`) or a plain type the team designates.
+  - **Story ↔ Test Case link type** — commonly `Tests` (Xray) or `relates to`.
+- **Conventions file**: the same `./.agentex/test-template.md` — its "Jira-specific settings"
+  section (added below the Design reference section) holds the two Jira-only values above.
+- **Steps**: no native Steps XML field on Jira — put Action/Expected pairs in a Markdown table
+  in the description instead (see the reference for the exact format and the file-based
+  create trick for long tables).
+- **Linking**: `--key` = the STORY, `--target-key` = the TEST CASE, using the link type's
+  outward name (e.g. `Tests`, not its inward complement `is tested by`).
+- Everything else — one test case per condition, confirm-before-create, coverage check —
+  applies exactly as written above for ADO.

--- a/skills/test-design/references/jira-test-case-mechanics.md
+++ b/skills/test-design/references/jira-test-case-mechanics.md
@@ -1,0 +1,126 @@
+# Tool: Test Case mechanics (`acli jira workitem` — Jira test issues)
+
+Test-Case-specific `acli` mechanics. Read this before creating or linking test cases, or when a
+command behaves unexpectedly. For shared basics (install, auth, JQL, current-sprint fetch), see
+the jira-integration skill's `references/jira-issues-cli.md`.
+
+## Fetch a story for analysis
+
+```bash
+acli jira workitem view --key <STORY_KEY> --json
+```
+
+Key field reference names (Jira REST/`acli` JSON output):
+- Acceptance Criteria → usually in `fields.description` (custom "Acceptance Criteria" field if
+  the project has one — confirm the field name/ID once per project) or a dedicated field like
+  `customfield_1xxxx`
+- Description → `fields.description` (Atlassian Document Format — read the ADF nodes, or request
+  `--json` and look for plain-text fallback)
+- Title → `fields.summary`
+- Sprint → `fields.sprint` / `fields.customfield_xxxxx` (board-dependent)
+
+Description/AC content comes back as **ADF** (Atlassian Document Format), not HTML — walk the
+`content` nodes to extract the design link (`type: inlineCard` / `type: link` mark) and any
+translation tables.
+
+## No native "Test Case" work-item type
+
+Unlike ADO, Jira has no built-in Test Case type or Steps field. Two situations, confirm which
+applies **once per project** (see Configuration in the parent skill):
+
+1. **Test-management plugin installed** (Xray, Zephyr Scale, etc.) — a real `Test` / `Test Case`
+   issue type exists with a dedicated steps field (often a custom field or a plugin-specific
+   `acli`/REST endpoint). Ask the user for the issue type name and, if `acli` doesn't expose the
+   plugin's step field directly, use the plugin's REST API instead (see its docs) — do not
+   guess a custom field ID.
+2. **No plugin** — use a plain issue type (commonly `Task`, sometimes a custom `Test Case` type
+   your team created) and put the steps in the **description** as a structured Markdown table
+   (converted to ADF by `acli`):
+
+```
+| # | Step | Expected Result |
+|---|---|---|
+| 1 | Given the customer lands on the homepage | Homepage loads |
+| 2 | When the customer clicks Next | Step 2 form is shown |
+```
+
+Rules:
+- Keep Action and Expected Result in separate columns — mirrors ADO's ActionStep/ValidateStep
+  split so coverage stays easy to audit.
+- To reference a design link, add a step row like:
+  `Open the design for reference: [DESIGN_URL]` before the validation rows.
+- Escape any literal `|` inside step text as `\|` so the Markdown table doesn't break.
+
+## Create a Test Case (file + description — avoid inlining long text)
+
+For long step tables, write the description to a file first, then load it, same reasoning as
+the ADO skill's `$STEPS` trick — long multi-line text with pipes/quotes breaks command-line
+parsing:
+
+```bash
+# 1. Write the steps table to a temp file (use the scratchpad dir)
+cat > "$SCRATCH/tc_steps.md" <<'EOF'
+| # | Step | Expected Result |
+|---|---|---|
+| 1 | ... | ... |
+EOF
+
+# 2. Load it and create the Test Case
+STEPS=$(cat "$SCRATCH/tc_steps.md")
+NEW_KEY=$(acli jira workitem create --project "$JIRA_PROJECT" --type "<confirmed Test Case type>" \
+  --summary "<Persona> || <Feature> || [condition]" \
+  --assignee "$JIRA_ASSIGNEE" \
+  --description "$STEPS" \
+  --json | jq -r '.key')
+```
+
+Notes:
+- The heredoc uses `'EOF'` (quoted) so `$` and backticks in the steps text are not expanded.
+- On Windows run via the **Bash** tool (Git Bash); quote values containing spaces/backslashes.
+- `--json | jq -r '.key'` returns just the new issue key — capture it for linking.
+- If a call returns a transient `5xx`, wait a couple of seconds and retry once.
+
+## Link test cases to the story
+
+After ALL test cases are created, link each to the parent story with the **confirmed link
+type** (see Configuration in the parent skill — commonly `Tests` from Xray, or `relates to` if
+no plugin is installed).
+
+```bash
+# --key = the STORY (source), --target-key = the TEST CASE
+acli jira workitem link --key <STORY_KEY> --link-type "Tests" --target-key <TC1_KEY>
+acli jira workitem link --key <STORY_KEY> --link-type "Tests" --target-key <TC2_KEY>
+```
+
+**Critical direction rule:** `--key` is the STORY, `--target-key` is the TEST CASE, using the
+outward name of the link type (e.g. `Tests`, not its inward complement `is tested by`).
+Reversing them flips the relationship as it reads on the story.
+
+Verify the links landed correctly:
+
+```bash
+acli jira workitem view --key <STORY_KEY> --json | jq '.fields.issuelinks'
+```
+
+## Deleting / removing Test Cases
+
+Unlike ADO's blocked Test Case delete, plain Jira issues (and most plugin Test types) CAN be
+deleted via `acli jira workitem delete --key <TC_KEY>` — but treat it as **destructive**:
+confirm with the user first, since it also removes its links and any execution history a
+test-management plugin tracked against it.
+
+If deletion is restricted by permissions, fall back to marking for manual cleanup:
+```bash
+acli jira workitem update --key <TC_KEY> --summary "ZZZ DELETE ME - <reason>"
+```
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Read a story | `acli jira workitem view --key <KEY> --json` |
+| Create a test case | `acli jira workitem create --type "<Test Case type>" --description "$STEPS" …` |
+| Link story → TC | `acli jira workitem link --key <STORY> --link-type "Tests" --target-key <TC>` |
+| Verify links | `acli jira workitem view --key <STORY> --json \| jq '.fields.issuelinks'` |
+| Delete a test case | `acli jira workitem delete --key <TC>` (confirm first) |
+| Mark TC for manual delete | `acli jira workitem update --key <TC> --summary "ZZZ DELETE ME - …"` |

--- a/skills/test-design/templates/test-template.md
+++ b/skills/test-design/templates/test-template.md
@@ -55,3 +55,9 @@ Where the design link lives in stories (e.g. "story description, under 'Figma De
 ```
 <location>
 ```
+## Jira-specific settings (leave blank if this project uses Azure DevOps)
+
+Filled once per project — the skill asks for these if missing and the tracker is Jira:
+
+- **Test Case issue type name:** `<e.g. Test (Xray) / Test Case (Zephyr) / Task>`
+- **Story ↔ Test Case link type:** `<e.g. Tests (Xray) / relates to>`


### PR DESCRIPTION
Adds a new jira-integration skill that lets AgenTeX read/write Jira issues via the Jira CLI, with reference docs covering CLI setup and issue field mechanics. Wires this new skill into task-estimation and test-design so estimation and test-case creation can pull from and push to Jira issues instead of (or alongside) Azure DevOps. Adds a new Jira test-case-mechanics reference under test-design explaining how test cases map to Jira issue fields, and extends the test case template accordingly. Adds the required Jira env keys to .env.example for configuration. Bumps the plugin manifest to register the new skill.