### PR TITLE
Add jira-integration skill (Jira & Confluence via acli)

### DIFF
--- a/skills/jira-integration/README.md
+++ b/skills/jira-integration/README.md
@@ -1,0 +1,116 @@
+# Jira & Confluence Integration
+
+> Let an AgenTeX test run **do the Atlassian paperwork for you** — file defects with screenshots
+> and video, build issue hierarchies, plan sprints, and publish the results as a Confluence page —
+> all against your real Jira/Confluence cloud, with a human confirming every change.
+
+**Status:** ✅ Verified end-to-end on a live Jira + Confluence tenant (Atlassian CLI `acli` 1.3.x).
+Read-only by default; nothing is written without explicit confirmation.
+
+---
+
+## Why it matters (by stakeholder)
+
+| You are a… | This gives you… |
+|---|---|
+| **QA engineer** | Failed test → a Jira bug filed automatically, with the screenshot and video attached and a link to the report — no manual copy-paste. |
+| **Dev / tech lead** | Defects land in your board already linked to the story/epic, in the right sprint, with reproducible evidence attached. |
+| **PM / manager** | A single Confluence page per run that embeds **live** Jira status (updates itself as issues move) — one link to share, always current. |
+| **Teammate trying it** | Copy `.env.example` → your own `.env`, add your token, one login command (see *Fast start* below). |
+
+---
+
+## What it can do
+
+**Jira** — check connectivity · read projects, issues, boards, sprints · search by JQL · build
+linked hierarchies (**Epic → Story / Task / Feature / Bug → Subtask**) · create, edit, transition,
+comment on, and link issues · create sprints and add issues to them · read fields, filters, and
+dashboards · **attach evidence** (screenshots, video, logs) to issues.
+
+**Confluence** — read and create spaces and blogs · author full page hierarchies with labels,
+comments, and access restrictions. A **copy-paste, ready-to-run** page-create recipe is included,
+so nobody has to hand-roll the boilerplate.
+
+**Jira ↔ Confluence together** — embed live Jira issues/JQL tables inside a Confluence page, and
+link Jira issues back to their Confluence pages. Both directions stay in sync automatically.
+
+---
+
+## Fast start (5 minutes)
+
+1. **Install the CLI.** One binary, direct download — no package manager. See
+   [`references/atlassian-cli.md`](references/atlassian-cli.md) for your OS.
+2. **Make your own credentials file** — copy the shared template, then fill in *your* values.
+   `.env.example` is the committed template (no secrets); `.env` is yours alone (gitignored,
+   never shared or committed):
+   ```bash
+   cp .env.example .env        # then edit .env and set the JIRA_* lines:
+   #   JIRA_SITE=your-site.atlassian.net
+   #   JIRA_EMAIL=you@example.com
+   #   JIRA_API_TOKEN=…        (create at id.atlassian.com → Security → API tokens)
+   ```
+3. **Log in** (the token is fed in securely — it never appears on the command line):
+   ```bash
+   set -a; . ./.env; set +a
+   echo "$JIRA_API_TOKEN" | acli jira auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token
+   acli jira auth status          # ✅ = you're connected
+   ```
+   Confluence is the same tool and the same credentials, with a separate one-time login
+   (`acli confluence auth login …`) — it needs Confluence enabled on your site.
+
+That's it — the agent follows the reference files from there.
+
+---
+
+## Safety, in plain terms
+
+This talks to your **real** Jira and Confluence, so it's built to be cautious:
+
+- 🔒 **Your API token stays secret.** Two files, one rule: **`.env.example`** is the shared,
+  committed template (placeholders only — safe to push); **`.env`** is *yours*, gitignored, and
+  holds the real token — never commit or share it. The token is never printed, logged, or put on a
+  command line. If a token is ever pasted into a chat, treat it as compromised and rotate it.
+- ✋ **Nothing is changed without your say-so.** Reading (view / search / list) is free; anything
+  that creates, edits, moves, or deletes is stated first and waits for your confirmation.
+- 🧪 **Every command is proven, not guessed.** Each one in the reference files was run against a
+  live site; the tricky Atlassian quirks are written down so they don't bite you.
+- ⚠️ **User administration is fenced off.** The CLI *can* deactivate/delete org user accounts, but
+  that's opt-in only, uses a different credential, and is never touched by a normal test run
+  (see *Scope* below).
+
+---
+
+## What's in this folder
+
+| File | For whom | What it is |
+|---|---|---|
+| [`SKILL.md`](SKILL.md) | the agent | Operating instructions: connection check, hierarchy/sprint rules, guardrails |
+| `README.md` | **people** | This guide |
+| [`references/atlassian-cli.md`](references/atlassian-cli.md) | agent + humans | Jira commands: install, auth, issues, hierarchy, boards, sprints, attachments |
+| [`references/confluence-cli.md`](references/confluence-cli.md) | agent + humans | Confluence: spaces, pages (REST), labels, comments, restrictions |
+| [`references/admin-cli.md`](references/admin-cli.md) | agent + humans | ⚠️ Opt-in org-admin user management — separate auth, confirm every write |
+
+It follows the same shape as the other AgenTeX integration skills (`azure-integration`): a
+`SKILL.md` plus one reference per surface, no bundled scripts — the agent runs the CLI (and, for
+the few things the CLI can't do, a documented REST call) directly.
+
+---
+
+## Scope — what's in and what's out
+
+The Atlassian CLI covers several products; this skill deliberately covers the ones a test run uses:
+
+- ✅ **Jira + Confluence** — the everyday QA surfaces. Fully covered and verified.
+- ⚠️ **Org admin** (user activate/deactivate/delete) — documented but **opt-in only**: different
+  credential, high blast radius, confirm-per-user, and never used by an automated run. Prefer
+  deactivate over delete; delete is effectively permanent.
+- ➖ **Atlassian Guard** and **Rovo Dev** — not things you'd drive from a test run; out of scope.
+
+New capabilities are added only when there's a real need, always keeping the read-first,
+confirm-before-write discipline.
+
+---
+
+<sub>Maturity note: validated across multiple live QA cycles (parallel + headed runs, with image
+and video evidence upload). Earlier reviews flagged gaps around attachments and Confluence
+authoring — all now closed and re-verified. Ready for the team to try.</sub>

--- a/skills/jira-integration/SKILL.md
+++ b/skills/jira-integration/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: jira-integration
+description: Interact with Jira from a QA/test run via the Atlassian CLI (`acli`) — login/auth, verify connectivity, read projects and issues, build linked issue hierarchies (Epic → Story/Task/Bug → Subtask), file defects, and manage boards & sprints. Use whenever a task needs to reach Jira (check the connection, look up or search issues, file a bug from a failed test, create an epic/story/subtask, plan a sprint) or when `acli` is not installed. Read the reference before the first `acli` command.
+---
+
+# Jira Integration
+
+## Role
+You connect a test run to Jira through the Atlassian CLI (`acli`, run via Bash). You use Jira
+to **support** testing — verifying connectivity, reading projects/issues, building linked issue
+hierarchies, filing or transitioning defects, and organizing work into sprints — not to
+administer the site. Prefer read-only commands; get explicit confirmation before any write
+(create / edit / transition / comment / delete, or any board/sprint change).
+
+## Tool
+Setup, install, auth, and all commands live in this skill's `references/` folder. **Read the
+reference file BEFORE the first `acli` command in a session**, and again whenever a command
+behaves unexpectedly:
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/atlassian-cli.md`** — Atlassian CLI
+  (`acli`) for **Jira**: install-if-missing (direct binary download per the official Windows guide),
+  auth (browser + API token over stdin), reading projects/issues (+ the `--json` field-shape
+  gotcha), writing issues, building a linked hierarchy with `--parent`, and managing boards &
+  sprints (including the REST fallback for adding existing issues to a sprint).
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/confluence-cli.md`** — the **same
+  `acli` binary** for **Confluence** (`acli confluence`): spaces, pages, blogs. Confluence auth is
+  separate from Jira and needs a Confluence license on the site (fails as BLOCKED otherwise);
+  pages are read-only in acli (author via the `/wiki/rest/api` REST fallback).
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/admin-cli.md`** — ⚠️ **opt-in, high
+  blast radius.** Org-admin user management (`acli admin user` activate/deactivate/**delete** real
+  accounts). Separate org API key (not the Jira token), every command destructive, confirm-per-user.
+  **Out of scope for automated/CI test runs** — read this ONLY when the user explicitly asks for
+  user-management automation.
+
+## Verify the connection first
+Before any read/write Jira step, confirm auth is working and do not proceed on failure:
+
+```bash
+acli --help            # installed?  (install per the reference if missing)
+acli jira auth status  # PASS = an authenticated account/site is shown
+```
+
+If not authenticated, log in with the API token over stdin (credentials from `.env`, gitignored):
+
+```bash
+echo "$JIRA_API_TOKEN" | acli jira auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token
+```
+
+## Building hierarchies & sprints
+- Jira's hierarchy is fixed: **Epic → (Story | Task | Feature | Bug) → Subtask**. Create top-down
+  and pass each child `--parent <key-from-the-previous-create>`. A **Subtask must parent to a
+  standard issue** (Story/Task/Bug), never directly to an Epic. Verify with `search --jql "parent = <KEY>"`.
+- Sprints live on a **board** — get the board id via `acli jira board search`, then
+  `acli jira sprint create --board <id> --name "…"`. acli has no "add to sprint" command; add
+  existing issues via the Agile REST API (see the reference). Subtasks inherit their parent's sprint.
+
+## Rules
+- Preflight `acli --help` before use; install per the reference if it's missing.
+- **Never print or log secrets** — API tokens, full emails, auth headers. Keep values in `.env`
+  (`JIRA_SITE`, `JIRA_EMAIL`, `JIRA_API_TOKEN`) and pass the token over stdin (acli) or via
+  basic-auth env interpolation (curl) — never echo it or place it on the command line.
+- Default to read-only (`workitem view`, `workitem search`, `project list`). **Confirm with the
+  user before any write** — create, edit, transition, comment, delete, or any board/sprint change —
+  and state exactly what will be created/changed first (writes hit live Jira and are not test data).
+- `project list` requires a flag (`--limit`/`--recent`/`--paginate`); prefer table output over
+  `--json` for reliable field values (acli nests JSON fields under `versionedRepresentations`).
+- In CI/non-interactive shells, authenticate from env vars / a secret store — never hardcode.

--- a/skills/jira-integration/references/admin-cli.md
+++ b/skills/jira-integration/references/admin-cli.md
@@ -1,0 +1,47 @@
+# Tool: atlassian-cli (`acli`) — Organization Admin  ⚠️ HIGH BLAST RADIUS
+
+**Same binary as Jira/Confluence**, but a fundamentally different surface: `acli admin` manages
+**real user accounts in your Atlassian organization**. Every `admin user` subcommand *changes a
+person's account state* — there is **no read/list command**. Treat this as a destructive tool.
+
+> Scope note: this reference exists only because user-management automation was explicitly
+> requested. It is **opt-in and confirm-before-every-write**. A routine test run must never call
+> `admin user …`. If you're here by accident, stop — use the Jira/Confluence references instead.
+
+## Separate auth — a different credential entirely
+`admin` does **not** use the Jira/Confluence API token in `.env`. It needs an **organization API
+key** tied to an **org-admin email**:
+- Create at **https://admin.atlassian.com → Settings → API keys** (org-admin privilege required).
+- Store as its own env var, e.g. `ATLASSIAN_ADMIN_EMAIL` and `ATLASSIAN_ADMIN_API_KEY` in `.env`
+  (gitignored) — **do not** reuse `JIRA_API_TOKEN`; it will not work and must not be conflated.
+- Login (key over STDIN, never argv):
+  ```bash
+  echo "$ATLASSIAN_ADMIN_API_KEY" | acli admin auth login --email "$ATLASSIAN_ADMIN_EMAIL" --token
+  acli admin auth status     # confirm the admin session
+  acli admin auth logout     # end it as soon as the task is done
+  ```
+- If not authenticated: `✗ unauthorized: use 'acli admin auth login'` — that's BLOCKED (missing
+  org API key), not a bug. Do not attempt to substitute the Jira token.
+
+## Commands — ALL destructive (confirm each, per user)
+`acli admin user` has no list/view; the four verbs each mutate managed accounts:
+
+| Command | Effect | Reversible? |
+|---|---|---|
+| `acli admin user deactivate --email <a,b>` \| `--id <id>` | Suspends the account(s) | Yes — via `activate` |
+| `acli admin user activate --email <a,b>` \| `--id <id>` | Re-enables a deactivated account | — |
+| `acli admin user delete --email <a>` \| `--id <id>` | **Deletes a managed account** | Only within the grace window via `cancel-delete` |
+| `acli admin user cancel-delete --id <id>` | Cancels a pending deletion | — |
+
+Inputs: `--email` (comma-separated), `--id` (account IDs), or `--from-file <list>`; `--json` for output.
+
+## MANDATORY guardrails for this reference
+- **Never run `admin user delete`/`deactivate` without explicit, specific per-user confirmation.**
+  State the exact accounts (emails/IDs) and the exact action, and get a "yes" for *those users*
+  before executing. Approval for one action never carries to another.
+- **No bulk/`--from-file` deletes** without the user reviewing the full list first.
+- **`delete` is effectively irreversible** (only cancellable inside Atlassian's grace window) —
+  prefer `deactivate` unless permanent removal is explicitly intended.
+- Never authenticate admin speculatively; log out (`admin auth logout`) when finished.
+- Same secret rules: org API key via STDIN only, kept in `.env`, never printed/logged/echoed.
+- This tool is **out of scope for automated/CI test runs** — interactive, human-confirmed use only.

--- a/skills/jira-integration/references/atlassian-cli.md
+++ b/skills/jira-integration/references/atlassian-cli.md
@@ -1,0 +1,144 @@
+# Tool: atlassian-cli (`acli`)
+
+Atlassian command-line tool. Read this when a task needs Jira (view/search issues, build an
+issue hierarchy, file a defect, manage sprints) or when `acli` is missing.
+Official docs: https://developer.atlassian.com/cloud/acli/  ·  Verified against acli **1.3.x**.
+
+## Preflight & install
+- Preflight: `acli --help` (verify it's installed) and `acli jira auth status` (check auth).
+- If missing, install (there is **no** winget package — download the binary directly):
+  - **Windows (per https://developer.atlassian.com/cloud/acli/guides/install-windows/):**
+    - x86-64: `Invoke-WebRequest -Uri https://acli.atlassian.com/windows/latest/acli_windows_amd64/acli.exe -OutFile acli.exe`
+    - ARM64:  `Invoke-WebRequest -Uri https://acli.atlassian.com/windows/latest/acli_windows_arm64/acli.exe -OutFile acli.exe`
+    - Move `acli.exe` into a folder on your PATH (e.g. a personal `bin`), then open a new shell.
+  - **macOS / Linux:** download the matching binary from https://developer.atlassian.com/cloud/acli/guides/ , `chmod +x acli`, move to `/usr/local/bin`.
+- Verify after install: `acli --help`.  CLI versions are supported ~6 months after release — update periodically.
+
+## Auth
+- `acli jira auth login --site <your-site>.atlassian.net --web` — interactive browser login.
+- API token (non-interactive) — the token is read from **STDIN**, never passed in argv:
+  `echo "$JIRA_API_TOKEN" | acli jira auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token`
+  - Flags: `-s/--site`, `-e/--email`, `--token` (read token from stdin), `-w/--web`.
+  - Create a token at https://id.atlassian.com/manage-profile/security/api-tokens
+  - Keep values in `.env` (gitignored): `JIRA_SITE`, `JIRA_EMAIL`, `JIRA_API_TOKEN`. Load with
+    `set -a; . ./.env; set +a`. Do NOT echo the token or place it on the command line.
+- `acli jira auth status` — show the active site/account (PASS = an authenticated account is shown).
+- `acli jira auth logout` — sign out · `acli jira auth switch` — switch between accounts.
+
+## Read — projects & issues
+- **Don't know the project key yet?** Start here: `acli jira project list --limit 100`
+  (or `--recent`) to discover keys, then use the key in every command below.
+- `acli jira project list --limit 100` — list projects. **A flag is required** — one of
+  `--limit <n>` (default 30), `--recent`, or `--paginate`; bare `project list` errors out.
+- `acli jira project view --key <KEY>` — one project's detail (flag is **`--key`**, not positional).
+- `acli jira workitem view <ISSUE-KEY>` — show one issue (table view is the most reliable).
+- `acli jira workitem search --jql "<JQL>" --limit 200` — JQL search. Useful queries:
+  - `project = SCRUM ORDER BY created ASC` — everything in a project
+  - `parent = SCRUM-5` — children of an epic/issue (verify a hierarchy)
+  - `issuetype = Epic AND summary ~ "Login"` — find an epic by name
+- **`--json` gotcha:** acli's JSON nests fields under `versionedRepresentations`, not a flat
+  `fields` object, so naive `.fields.status` parsing yields `undefined`. Prefer the default
+  **table output** for reliable field values; use `--json` only when you handle that shape.
+
+## Write — issues (confirm with the user first)
+- Create (prints the new key + URL, e.g. `✓ Work item SCRUM-5 created: …/browse/SCRUM-5`):
+  `acli jira workitem create --project <KEY> --type <Type> --summary "…" --description "…"`
+  - `--type` accepts the project's configured types (e.g. Epic, Story, Task, Feature, Bug, Subtask).
+  - `-a/--assignee <email|@me|default>`, `-l/--label a,b`, `--description-file <f>`, `--json`.
+- Edit: `acli jira workitem edit --key "KEY-1,KEY-2" --summary "…"` (also `-a`, `-d`, `-l`, `-y`).
+- Transition: `acli jira workitem transition --key "<KEY>" --status "In Progress"` — note the
+  **`--key` flag** (not a positional key); accepts a comma-separated list or `--jql`.
+- Comment: `acli jira workitem comment create --key "<KEY>" --body "…"` (`comment` is a command
+  group: `create` / `list` / `update` / `delete` / `visibility`; `--body-file` / `--editor` also work).
+- Link: `acli jira workitem link create --out <KEY> --in <KEY> --type <Type>` — `link` is a group
+  (`create` / `list` / `delete` / `type`). Link types on this site: **Blocks, Cloners, Duplicate,
+  Relates** (`acli jira workitem link type` lists them). `--out` = outward issue, `--in` = inward.
+- Assign: `acli jira workitem assign --key "<KEY>" --assignee <email|@me|default>`.
+- Clone: `acli jira workitem clone --key "<KEY>" --to-project "<KEY>"` — **`--to-project` is
+  required** (clone always targets a project; `clone --key` alone errors).
+- Watchers: `acli jira workitem watcher remove --key "<KEY>" …` · `workitem list-watchers --key "<KEY>"`
+  (uses **`--key`**, not positional; there is no `watcher add` — `watcher list` is deprecated).
+- Attachments: `acli jira workitem attachment list --key "<KEY>"` / `attachment delete`. **acli
+  cannot UPLOAD** — see "Attach evidence" below for the REST recipe (screenshots, videos, logs).
+- Also available: `archive` / `unarchive` (`--key`), `delete --key "<KEY>" --yes`, `create-bulk`.
+
+## Attach evidence to an issue (screenshots, video, logs)
+acli has **no attachment-upload** command — use the REST API. The `X-Atlassian-Token: no-check`
+header is **mandatory** (without it the upload is rejected/blocked as XSRF), and the form field
+**must** be named `file`. Verified live (returns a JSON array with the new attachment id):
+```bash
+curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" -X POST \
+  -H "X-Atlassian-Token: no-check" \
+  -F "file=@path/to/evidence.png" \
+  "https://$JIRA_SITE/rest/api/3/issue/<KEY>/attachments"
+```
+- Works for any binary — `.png`, `.webm` video, `.zip`, `.log`. Repeat `-F "file=@…"` to upload
+  several in one call. Verify with `acli jira workitem attachment list --key "<KEY>"`.
+- **Size limit:** Jira Cloud defaults to **10 MB per file**. Check first (`ls -l`) and zip large
+  evidence sets; a long regression video can exceed the cap.
+
+## Build a linked hierarchy (`--parent`)
+Jira's hierarchy is fixed: **Epic → (Story | Task | Feature | Bug) → Subtask**. Create top-down
+and pass `--parent` the key returned by the previous create:
+
+```bash
+# 1) Epic (top — no parent)
+acli jira workitem create --project SCRUM --type Epic --summary "Login"          # -> SCRUM-5
+# 2) Standard issues parented to the epic
+acli jira workitem create --project SCRUM --type Story   --parent SCRUM-5 --summary "…"   # -> SCRUM-6
+acli jira workitem create --project SCRUM --type Bug     --parent SCRUM-5 --summary "…"   # -> SCRUM-9
+# 3) Subtask parented to a STANDARD issue (NOT directly to an epic)
+acli jira workitem create --project SCRUM --type Subtask --parent SCRUM-9 --summary "…"   # -> SCRUM-10
+```
+- A **Subtask must attach to a standard issue** (Story/Task/Bug), never directly to an Epic.
+- Verify links with `acli jira workitem search --jql "parent = <KEY>"`.
+
+## Boards & sprints
+Mind the flag names — they are inconsistent across these commands (verified against acli 1.3.x):
+- `acli jira board search [--name <n>] [--project <KEY>] [--limit <n>]` — find a board and its **Id**.
+  (`board list` is a command *group*, not a lister — use `board search`.)
+- `acli jira board list-sprints --id <boardId> [--state active,closed,future]` — all sprints on a board
+  (flag is **`--id`**, the board id — not `--board`, not positional).
+- `acli jira board list-projects --id <boardId>` — projects mapped to a board.
+- `acli jira sprint create --board <id> --name "…" [--goal "…"] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`
+  — creates a sprint (starts in state `future`; prints the sprint URL/id). Here the flag **is** `--board`.
+- `acli jira sprint view --id <sprintId>` — sprint detail (flag is `--id`).
+- `acli jira sprint list-workitems --board <id> --sprint <id>` — list a sprint's issues (both required).
+- `acli jira sprint update …` — start/close or re-date a sprint · `acli jira sprint delete`.
+- **Adding existing issues to a sprint:** acli has **no** `sprint add` command. Use Jira's Agile
+  REST API (basic auth = email:token from `.env`; token never echoed). Standard issues only —
+  subtasks inherit their parent's sprint automatically and the API rejects them:
+  ```bash
+  curl -s -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+    -X POST "https://${JIRA_SITE}/rest/agile/1.0/sprint/<SPRINT_ID>/issue" \
+    -H "Content-Type: application/json" \
+    -d '{"issues": ["SCRUM-5","SCRUM-6"]}'      # HTTP 204 = success (no body)
+  ```
+
+## Fields, filters & dashboards
+- **Fields:** `acli jira field` exposes only `create` / `update` / `delete` (custom fields) —
+  there is **no list/search**, so you cannot enumerate a project's fields via acli. To read the
+  field catalog, use the REST API: `curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" "https://$JIRA_SITE/rest/api/3/field"`.
+- **Filters:** `acli jira filter list --my` or `--favourite` (one is **required**) ·
+  `acli jira filter search --name "…"` · `filter view --id <id>` · `filter update` ·
+  `filter list-columns` / `reset-columns` · `filter add-favourite` · `filter change-owner`.
+- **Dashboards:** `acli jira dashboard search [--name <n>] [--owner <email>] [--limit <n>]` —
+  the only dashboard subcommand (read-only).
+
+## Jira ↔ Confluence integration (same-tenant)
+When Jira and Confluence share one cloud site (same accountId on both `/rest/api/3/myself` and
+`/wiki/rest/api/user/current`), they integrate natively — no legacy application links
+(`/rest/applinks/...` returns 404 on cloud, which is expected):
+- **Confluence page → live Jira:** embed the `jira` macro in storage-format page body —
+  single issue: `<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">SCRUM-9</ac:parameter></ac:structured-macro>`;
+  live table: same macro with `<ac:parameter ac:name="jqlQuery">sprint = 36</ac:parameter>`.
+  Embedding it makes Confluence **auto-create a remote link back on the Jira issue**.
+- **Jira issue → Confluence page:** add a remote link —
+  `POST /rest/api/3/issue/<KEY>/remotelink` with `{object:{url,title}}`; list via `GET` on the same path.
+
+## Notes
+- `acli` is a standalone binary — **not** an npm package; install by direct download, not `npm install`.
+- Treat the API token, full email, and auth headers as sensitive — never print or log them.
+  Pass the token via `JIRA_API_TOKEN` over stdin (acli) or basic-auth env interpolation (curl) only.
+- Default to read-only (`view`, `search`, `list`); confirm before any create / edit / transition /
+  comment / delete, or any sprint/board write.

--- a/skills/jira-integration/references/confluence-cli.md
+++ b/skills/jira-integration/references/confluence-cli.md
@@ -1,0 +1,112 @@
+# Tool: atlassian-cli (`acli`) — Confluence
+
+**Same binary as Jira.** `acli confluence …` is a command group of the *same* Atlassian CLI
+documented in `atlassian-cli.md` — nothing extra to install. Read this when a task needs
+Confluence (spaces, pages, blog posts). Verified against acli **1.3.x**.
+
+## Prerequisite: a Confluence license on the site
+Confluence auth is **separate from Jira** and requires Confluence to be provisioned on the site
+for the account. If the site has Jira only (common on the free Atlassian Cloud tier), Confluence
+auth fails even with a valid Jira token — this is a licensing gap, **not** a CLI/command error:
+- `acli confluence auth login …` → `✗ Error: authentication failed`
+- `curl .../wiki/rest/api/space` → `HTTP 401` + an HTML login page
+
+To enable: add the Confluence product to the Atlassian Cloud site (admin.atlassian.com), then
+authenticate. Do not treat this as a bug to work around — surface it as BLOCKED (prerequisite).
+
+## Auth (once Confluence is licensed)
+Separate login from Jira, but the **same** site + email + API token (token over STDIN, never argv):
+```bash
+echo "$JIRA_API_TOKEN" | acli confluence auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token
+acli confluence auth status     # PASS = authenticated account/site shown
+acli confluence auth logout     # sign out
+```
+
+## Read — spaces, pages, blogs
+- **Pick a target space FIRST (mandatory before any page/blog write).** List spaces, then resolve
+  the chosen key to the numeric id the REST page/blog calls need:
+  ```bash
+  acli confluence space list                                   # discover space keys
+  curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" \
+    "https://$JIRA_SITE/wiki/rest/api/space/<KEY>" | \
+    node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const s=JSON.parse(d);console.log("id:",s.id,"home:",s.homepageId||"?")})'
+  ```
+- `acli confluence space list [--type personal|global] [--keys A,B] [--expand description,homepage] [--json]`
+  — list spaces.
+- `acli confluence space view --id <spaceId> [--include-all] [--labels] [--json]` — one space's detail.
+- `acli confluence page view --id <pageId> [--body-format storage|atlas_doc_format|view] [--json]`
+  — one page (the `page` group is **read-only** in acli — only `view`).
+- `acli confluence blog list` · `acli confluence blog view --id <id>` — blog posts.
+
+## Write — spaces & blogs (confirm with the user first)
+- `acli confluence space create --key <KEY> --name "…" [--description "…"] [--alias <slug>]`
+- `acli confluence space update --key <KEY> …` · `space archive --key <KEY>` / `space restore --key <KEY>`
+- **No `space delete` in acli** (archive only). To hard-delete, `DELETE /wiki/rest/api/space/<KEY>`
+  — returns **HTTP 202** (async long-running task; the space disappears shortly after).
+- Blog: `acli confluence blog create --space-id <numericId> --title "…" --body "<p>…</p>"` — note
+  **`--space-id`** (the space's numeric id from `GET /space/<KEY>`), *not* `--space`/`--space-key`.
+  Also `--status draft`, `--private`, `--from-file`, `--from-json`. `blog list` / `blog view --id`.
+- **Pages have no create/update/delete in acli** (only `page view --id`). Author/edit page content
+  via the Confluence REST API (`/wiki/rest/api`). See the operations below.
+
+## Page operations via REST (`/wiki/rest/api`) — confirm before writing
+acli's `page` group is view-only; do all page authoring through REST. Base path is
+**`/wiki/rest/api/...`** (note the `/wiki` prefix), basic auth = email:token.
+
+| Operation | Call |
+|---|---|
+| Get space numeric id / homepage | `GET /space/<KEY>` |
+| List pages in a space | `GET /content?spaceKey=<KEY>&type=page&limit=25&expand=version` |
+| Create a page | `POST /content` with `{type:"page",title,space:{key},body:{storage:{value:"<html>",representation:"storage"}}}` |
+| **Nest under a parent** (hierarchy) | add `ancestors:[{id:"<parentId>"}]` to the create/update body |
+| **Embed a live Jira issue/JQL** | put a `jira` macro in the storage body: `<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">SCRUM-9</ac:parameter></ac:structured-macro>` (or `ac:name="jqlQuery"` for a table). Auto-creates a backlink on the Jira issue. |
+| Update a page | `PUT /content/<id>` with a **bumped** `version:{number:N+1}` + new `body` (fetch current version first) |
+| Delete (to trash) | `DELETE /content/<id>` |
+| View content (rendered/storage) | `GET /content/<id>?expand=body.storage,version,ancestors` |
+| List child pages | `GET /content/<id>/child/page?limit=25` |
+| Labels | `POST /content/<id>/label` with `[{prefix:"global",name:"qa"}]` · `GET`/`DELETE` same path |
+| Comment (footer) | `POST /content` with `{type:"comment",container:{id,type:"page"},body:{storage:{…}}}` |
+| **Page restrictions** (Confluence's "assign / permission to people") | `PUT /content/<id>/restriction` with `[{operation:"update",restrictions:{user:[{type:"known",accountId:"<id>"}]}}]` · `DELETE` to clear |
+| Current user accountId (for restrictions/mentions) | `GET /wiki/rest/api/user/current` |
+
+Body format is **storage** (Confluence XHTML); Confluence macros are `<ac:structured-macro ac:name="info|status|…">…</ac:structured-macro>`.
+
+### ⚠️ Windows UTF-8 gotcha (verified)
+Passing page HTML with non-ASCII chars (em-dash `—`, emoji, curly quotes) through
+`bash → -d '…'` on Windows corrupts the bytes → Confluence rejects it with
+`JsonParseException: Invalid UTF-8 start byte 0x97`. **Fix:** build the JSON and POST it from a
+single **Node script** using `Buffer.from(JSON.stringify(payload),"utf8")` and node's `https`
+(don't hand the content to curl `-d`, and don't rely on `/tmp` — node on Windows resolves it to
+`C:\tmp`). ASCII-only bodies are fine either way.
+
+### Runnable page-create (UTF-8-safe, copy-paste)
+Write the storage-format HTML to a file, then run this — it encapsulates the Node HTTPS +
+UTF-8 pattern so you don't reinvent it each time. Args: `<SPACE_KEY> <TITLE> <BODY_FILE> [PARENT_ID]`.
+Reads `JIRA_SITE`/`JIRA_EMAIL`/`JIRA_API_TOKEN` from the env (load `.env` first).
+```bash
+node -e '
+const https=require("https"),fs=require("fs");
+const [key,title,bodyFile,parent]=process.argv.slice(1);
+const site=process.env.JIRA_SITE, auth="Basic "+Buffer.from(process.env.JIRA_EMAIL+":"+process.env.JIRA_API_TOKEN).toString("base64");
+const o={type:"page",title,space:{key},body:{storage:{value:fs.readFileSync(bodyFile,"utf8"),representation:"storage"}}};
+if(parent) o.ancestors=[{id:parent}];
+const data=Buffer.from(JSON.stringify(o),"utf8");
+const r=https.request({host:site,path:"/wiki/rest/api/content",method:"POST",headers:{Authorization:auth,"Content-Type":"application/json","Content-Length":data.length}},x=>{let b="";x.on("data",c=>b+=c);x.on("end",()=>{const j=JSON.parse(b);console.log(x.statusCode===200?("OK "+j.id+" :: "+j.title):("ERR "+x.statusCode+" "+(j.message||b).slice(0,160)));});});
+r.write(data); r.end();
+' "SD" "My Report" "./body.html" "720898"
+```
+Update a page the same way with `method:"PUT"`, path `/wiki/rest/api/content/<id>`, and a bumped
+`version:{number:N+1}` (fetch the current version first).
+
+## Notes
+- **Windows paths with spaces / cwd persistence:** the working directory is not guaranteed to
+  persist between Bash tool calls, and a repo path containing a space (e.g. `agentex-main (1)`)
+  breaks a bare `cd` — commands fail with "No such file or directory." Re-issue `cd` with the
+  **absolute, quoted** path on every call that needs it (this is separate from the UTF-8 gotcha above).
+- Confluence REST base path is `/wiki/rest/api/...` (note the `/wiki` prefix), unlike Jira's `/rest/api/...`.
+- "Assign a page to a team/person" in Confluence = **page restrictions** (view/update permissions),
+  not a Jira-style single assignee. There is no per-page "assignee" field.
+- Same secret rules as Jira: token from `.env` (`JIRA_SITE`/`JIRA_EMAIL`/`JIRA_API_TOKEN`), over
+  stdin (acli) or basic-auth env interpolation (curl/node) — never echoed or placed in argv.
+- Default to read-only (`list`, `view`); confirm before any create / update / archive / delete /
+  restrict.


### PR DESCRIPTION
## Summary
Adds a new `jira-integration` skill that lets an AgenTeX run reach **Jira and
Confluence** through Atlassian's official CLI (`acli`), following the same
structure as the existing `azure-integration` skill (SKILL.md + references,
no scripts).

## What it does
- **Jira** — verify connectivity; read projects, issues, boards, sprints; JQL
  search; build linked hierarchies (Epic → Story/Task/Bug → Subtask); create,
  edit, transition, comment on, and link issues; create sprints and add issues
  to them; attach evidence (screenshots/video/logs) to issues.
- **Confluence** — read/create spaces and blogs; author page hierarchies with
  labels, comments, and restrictions (via the `/wiki/rest/api` REST fallback,
  since `acli`'s page group is view-only).
- **Jira ↔ Confluence** — embed live Jira issues/JQL in a Confluence page and
  link issues back to pages; the macro auto-creates the backlink.

## Files
- `skills/jira-integration/SKILL.md` — role, connection check, guardrails
- `skills/jira-integration/README.md` — stakeholder guide
- `skills/jira-integration/references/atlassian-cli.md` — Jira commands
- `skills/jira-integration/references/confluence-cli.md` — Confluence
- `skills/jira-integration/references/admin-cli.md` — ⚠️ opt-in org-admin
  user management (separate auth, confirm-per-write)

## Safety
- Read-only by default; every write (create/edit/transition/comment/publish,
  sprint & board changes) is confirm-first.
- API token stays in `.env` (gitignored) and is passed via STDIN / auth header
  — never printed, logged, or placed in argv.

## Verification
Every command in the references was run live against a real Jira + Confluence
Cloud tenant (acli 1.3.x). Known quirks are documented inline (flag
inconsistencies, the `--json` field-shape trap, Windows UTF-8/path gotchas,
attachment `X-Atlassian-Token` header, Confluence license requirement).
