### PR TITLE
Add figma integration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "agentex",
   "displayName": "AgenTeX",
-  "version": "0.9.0",
+  "version": "0.8.1",
   "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli. Test steps can call your APIs and query your database from a user-defined integration catalog, and ask your project's knowledge base a question mid-run. Reads Figma designs into user stories & test conditions (and syncs design↔code via Code Connect), and tracks work in Jira & Confluence via the Atlassian CLI. On Azure DevOps it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
   "author": {
     "name": "Mohamed Elgazzar",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "agentex",
   "displayName": "AgenTeX",
-  "version": "0.8.1",
-  "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli. Test steps can call your APIs and query your database from a user-defined integration catalog, and ask your project's knowledge base a question mid-run. On Azure DevOps it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
+  "version": "0.9.0",
+  "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli. Test steps can call your APIs and query your database from a user-defined integration catalog, and ask your project's knowledge base a question mid-run. Reads Figma designs into user stories & test conditions (and syncs design↔code via Code Connect), and tracks work in Jira & Confluence via the Atlassian CLI. On Azure DevOps it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
   "author": {
     "name": "Mohamed Elgazzar",
     "email": "mhmd.elgazzar.sqe@gmail.com"
@@ -27,6 +27,10 @@
     "test-cases",
     "api-testing",
     "database",
-    "sql-server"
+    "sql-server",
+    "figma",
+    "code-connect",
+    "jira",
+    "confluence"
   ]
 }

--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,13 @@ KB_ASK_BASE_URL=http://localhost:3000
 KB_PROJECT=travel-insurance
 # Shared secret sent as x-api-key (required when the server has it set). Ask ops for the key.
 KB_ASK_API_KEY=
+
+
+# ─── Figma (figma-integration skill — REST reads + @figma/code-connect CLI) ───
+# Personal access token. Scopes: File content = Read (design reads — the everyday use);
+# add Code Connect = Write only if you'll publish component↔code mappings.
+# Create at Figma → Settings → Security → Personal access tokens. Sent via the
+# X-Figma-Token header / FIGMA_ACCESS_TOKEN — never on the command line.
+FIGMA_ACCESS_TOKEN=
+# Optional: the file key from a Figma URL (…/design/<FILE_KEY>/…) for REST reads.
+FIGMA_FILE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,18 @@ KB_PROJECT=travel-insurance
 KB_ASK_API_KEY=
 
 
+# ─── Jira Cloud (jira-integration skill, Atlassian acli) ──────────────────────
+# acli reads the token from STDIN — never passed on the command line or committed.
+# Create at https://id.atlassian.com/manage-profile/security/api-tokens
+JIRA_SITE=your-site.atlassian.net
+JIRA_EMAIL=you@example.com
+JIRA_API_TOKEN=
+# Optional org-admin (⚠️ high blast radius — user activate/deactivate/delete).
+# SEPARATE org API key (not the Jira token above). admin.atlassian.com → API keys.
+ATLASSIAN_ADMIN_EMAIL=
+ATLASSIAN_ADMIN_API_KEY=
+
+
 # ─── Figma (figma-integration skill — REST reads + @figma/code-connect CLI) ───
 # Personal access token. Scopes: File content = Read (design reads — the everyday use);
 # add Code Connect = Write only if you'll publish component↔code mappings.

--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ KB_ASK_API_KEY=
 # Create at https://id.atlassian.com/manage-profile/security/api-tokens
 JIRA_SITE=your-site.atlassian.net
 JIRA_EMAIL=you@example.com
+# This SAME token also authenticates Confluence — no separate token needed
+# (run `acli confluence auth login` once; separate session, same credential).
 JIRA_API_TOKEN=
 # Optional org-admin (⚠️ high blast radius — user activate/deactivate/delete).
 # SEPARATE org API key (not the Jira token above). admin.atlassian.com → API keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to AgenTeX are documented here.
 
+## [Unreleased]
+### Added
+- **`figma-integration` skill** — read a Figma design → user stories & test conditions that feed
+  `test-design`/`browser-testing` (the QA-pipeline use), via the Figma REST API; optionally sync
+  design↔code via Figma's official CLI `@figma/code-connect` (Code Connect, two authoring modes:
+  parser `.figma.tsx` + CLI, or template `.figma.ts` + Figma MCP). Read-only by default,
+  confirm-before-publish. Reference: `figma-cli.md`. REST reads verified live.
+- `test-design` now hands off to `figma-integration` when a story carries a Figma link.
+
 ## [0.8.1] — 2026-07-21
 ### Added
 - `/ask-kb <question>` command — ask the project's Knowledge Base a question directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to AgenTeX are documented here.
 
-## [Unreleased]
+## [0.9.0] — 2026-07-25
 ### Added
 - **`figma-integration` skill** — read a Figma design → user stories & test conditions that feed
   `test-design`/`browser-testing` (the QA-pipeline use), via the Figma REST API; optionally sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to AgenTeX are documented here.
   parser `.figma.tsx` + CLI, or template `.figma.ts` + Figma MCP). Read-only by default,
   confirm-before-publish. Reference: `figma-cli.md`. REST reads verified live.
 - `test-design` now hands off to `figma-integration` when a story carries a Figma link.
+- **`jira-integration` skill** — reach Jira & Confluence via the Atlassian CLI (`acli`): file
+  defects with screenshot/video evidence, build Epic→Story/Task/Bug→Subtask hierarchies, plan
+  sprints, and publish Confluence report pages that embed live Jira status. Read-only by default,
+  confirm-before-write. References: `atlassian-cli.md`, `confluence-cli.md`, `admin-cli.md`
+  (opt-in org admin). Verified live against a real tenant (acli 1.3.x).
 
 ## [0.8.1] — 2026-07-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to AgenTeX are documented here.
 
-## [0.9.0] — 2026-07-25
+## [Unreleased]
 ### Added
 - **`figma-integration` skill** — read a Figma design → user stories & test conditions that feed
   `test-design`/`browser-testing` (the QA-pipeline use), via the Figma REST API; optionally sync

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ your confirmation.
 | Skill | `skills/db-integration/SKILL.md` | Execute cataloged DB queries in test steps (`db:`) via a runner script |
 | Skill | `skills/ask-kb/SKILL.md` | Ask the project's KB Ask API in test steps (`kb:`) for advisory answers (never evidence) |
 | Skill | `skills/extent-report/SKILL.md` | Interactive HTML dashboard (`extent-report.html`) for a finished run |
+| Skill | `skills/figma-integration/SKILL.md` | Read a Figma design → user stories & test conditions that feed `test-design`/`browser-testing`; optionally sync design↔code via the `@figma/code-connect` CLI |
 | Agent | `agents/qa-executor.md` | Subagent that runs one test spec in its own isolated browser session |
 | Reference | `skills/browser-testing/references/playwright-cli.md` | The browser driver — setup & gotchas |
 | Reference | `skills/azure-integration/references/azure-cli.md` | `az` CLI — install/auth/common commands |
@@ -74,6 +75,7 @@ your confirmation.
 | Reference | `skills/api-integration/references/api-requests.md` | Runner usage + curl fallback for cataloged API requests |
 | Reference | `skills/db-integration/references/sqlcmd.md` | Runner usage + sqlcmd (SQL Server) for cataloged queries |
 | Reference | `skills/ask-kb/references/kb-ask-api.md` | KB Ask API contract, result handling & curl fallback |
+| Reference | `skills/figma-integration/references/figma-cli.md` | Figma REST reads (design → stories/specs) + `@figma/code-connect` CLI (install/auth/authoring) |
 | Scripts | `skills/*/scripts/*.js` | Deterministic runners & helpers: `run_api`, `run_db`, `ask_kb`, `preflight`, `init_run`, `merge_run` |
 | Templates | `skills/{api,db}-integration/templates/sample_{api,db}.json` | Catalog samples — scaffolded to `integration/` in your project |
 | Script | `skills/extent-report/scripts/make_html_report.js` | Standalone HTML dashboard generator (run via `node`) |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ your confirmation.
 | Skill | `skills/ask-kb/SKILL.md` | Ask the project's KB Ask API in test steps (`kb:`) for advisory answers (never evidence) |
 | Skill | `skills/extent-report/SKILL.md` | Interactive HTML dashboard (`extent-report.html`) for a finished run |
 | Skill | `skills/figma-integration/SKILL.md` | Read a Figma design → user stories & test conditions that feed `test-design`/`browser-testing`; optionally sync design↔code via the `@figma/code-connect` CLI |
+| Skill | `skills/jira-integration/SKILL.md` | Reach Jira & Confluence via the `acli` CLI — file defects, build issue hierarchies, plan sprints, publish reports |
 | Agent | `agents/qa-executor.md` | Subagent that runs one test spec in its own isolated browser session |
 | Reference | `skills/browser-testing/references/playwright-cli.md` | The browser driver — setup & gotchas |
 | Reference | `skills/azure-integration/references/azure-cli.md` | `az` CLI — install/auth/common commands |
@@ -76,6 +77,9 @@ your confirmation.
 | Reference | `skills/db-integration/references/sqlcmd.md` | Runner usage + sqlcmd (SQL Server) for cataloged queries |
 | Reference | `skills/ask-kb/references/kb-ask-api.md` | KB Ask API contract, result handling & curl fallback |
 | Reference | `skills/figma-integration/references/figma-cli.md` | Figma REST reads (design → stories/specs) + `@figma/code-connect` CLI (install/auth/authoring) |
+| Reference | `skills/jira-integration/references/atlassian-cli.md` | `acli` for Jira — install/auth, issues, hierarchy, boards, sprints, attachments |
+| Reference | `skills/jira-integration/references/confluence-cli.md` | `acli` for Confluence — spaces, pages (REST), labels, comments, restrictions |
+| Reference | `skills/jira-integration/references/admin-cli.md` | ⚠️ opt-in org-admin user management — separate auth, confirm-per-write |
 | Scripts | `skills/*/scripts/*.js` | Deterministic runners & helpers: `run_api`, `run_db`, `ask_kb`, `preflight`, `init_run`, `merge_run` |
 | Templates | `skills/{api,db}-integration/templates/sample_{api,db}.json` | Catalog samples — scaffolded to `integration/` in your project |
 | Script | `skills/extent-report/scripts/make_html_report.js` | Standalone HTML dashboard generator (run via `node`) |

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,5 +1,5 @@
 {
-  "//": "RECOMMENDED PERMISSIONS for AgenTeX (Browser Testing, Azure DevOps estimation, API/DB/KB integrations, Figma). Plugin settings.json cannot carry permission rules, so copy the blocks below into your PROJECT .claude/settings.json (merge with any existing 'permissions'). These pre-approve the safe/read-only commands, gate writes (deploys, Figma publish/unpublish) behind a prompt, and deny secret reads / destructive actions.",
+  "//": "RECOMMENDED PERMISSIONS for AgenTeX (Browser Testing, Azure DevOps estimation, API/DB/KB integrations, Figma, Jira/Confluence). Plugin settings.json cannot carry permission rules, so copy the blocks below into your PROJECT .claude/settings.json (merge with any existing 'permissions'). These pre-approve the safe/read-only commands, gate writes (deploys, Figma publish/unpublish, Jira/Confluence writes) behind a prompt, and deny secret reads / destructive actions.",
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
@@ -26,7 +26,19 @@
       "Bash(npx @figma/code-connect@latest --version)",
       "Bash(npx @figma/code-connect@latest connect create:*)",
       "Bash(npx @figma/code-connect@latest connect preview:*)",
-      "Bash(npx @figma/code-connect@latest connect parse:*)"
+      "Bash(npx @figma/code-connect@latest connect parse:*)",
+      "Bash(acli --version)",
+      "Bash(acli jira auth status)",
+      "Bash(acli jira project:*)",
+      "Bash(acli jira workitem view:*)",
+      "Bash(acli jira workitem search:*)",
+      "Bash(acli jira board:*)",
+      "Bash(acli jira sprint view:*)",
+      "Bash(acli jira sprint list-workitems:*)",
+      "Bash(acli confluence auth status)",
+      "Bash(acli confluence space list:*)",
+      "Bash(acli confluence space view:*)",
+      "Bash(acli confluence page view:*)"
     ],
     "ask": [
       "Bash(az boards work-item delete:*)",
@@ -36,7 +48,14 @@
       "Bash(az group create:*)",
       "Bash(npx @figma/code-connect@latest connect publish:*)",
       "Bash(npx @figma/code-connect@latest connect unpublish:*)",
-      "Bash(npx @figma/code-connect@latest connect migrate:*)"
+      "Bash(npx @figma/code-connect@latest connect migrate:*)",
+      "Bash(acli jira workitem create:*)",
+      "Bash(acli jira workitem edit:*)",
+      "Bash(acli jira workitem transition:*)",
+      "Bash(acli jira workitem delete:*)",
+      "Bash(acli jira sprint create:*)",
+      "Bash(acli confluence space create:*)",
+      "Bash(acli confluence blog create:*)"
     ],
     "deny": [
       "Read(./secrets/**)",

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,5 +1,5 @@
 {
-  "//": "RECOMMENDED PERMISSIONS for AgenTeX (Browser Testing + Azure DevOps task estimation). Plugin settings.json cannot carry permission rules, so copy the blocks below into your PROJECT .claude/settings.json (merge with any existing 'permissions'). These pre-approve the safe commands, gate destructive ones behind a prompt, and deny secret reads / destructive actions.",
+  "//": "RECOMMENDED PERMISSIONS for AgenTeX (Browser Testing, Azure DevOps estimation, API/DB/KB integrations, Figma). Plugin settings.json cannot carry permission rules, so copy the blocks below into your PROJECT .claude/settings.json (merge with any existing 'permissions'). These pre-approve the safe/read-only commands, gate writes (deploys, Figma publish/unpublish) behind a prompt, and deny secret reads / destructive actions.",
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
@@ -22,14 +22,21 @@
       "Bash(az keyvault secret list:*)",
       "Bash(az aks list:*)",
       "Bash(curl:*)",
-      "Bash(sqlcmd:*)"
+      "Bash(sqlcmd:*)",
+      "Bash(npx @figma/code-connect@latest --version)",
+      "Bash(npx @figma/code-connect@latest connect create:*)",
+      "Bash(npx @figma/code-connect@latest connect preview:*)",
+      "Bash(npx @figma/code-connect@latest connect parse:*)"
     ],
     "ask": [
       "Bash(az boards work-item delete:*)",
       "Bash(az webapp deploy:*)",
       "Bash(az storage blob upload:*)",
       "Bash(az aks get-credentials:*)",
-      "Bash(az group create:*)"
+      "Bash(az group create:*)",
+      "Bash(npx @figma/code-connect@latest connect publish:*)",
+      "Bash(npx @figma/code-connect@latest connect unpublish:*)",
+      "Bash(npx @figma/code-connect@latest connect migrate:*)"
     ],
     "deny": [
       "Read(./secrets/**)",

--- a/skills/figma-integration/README.md
+++ b/skills/figma-integration/README.md
@@ -1,0 +1,119 @@
+# Figma Integration
+
+> Let an AgenTeX run **use your Figma designs** — read a screen's real content to write user
+> stories and test conditions, verify the built UI matches the design, render frames as evidence
+> images, and (for a component library) keep design ↔ code in sync in Dev Mode.
+
+**Status:** ✅ Verified live against a real Figma tenant — all REST read endpoints and the
+`@figma/code-connect` CLI. Read-only by default; nothing is written without confirmation.
+
+---
+
+## Why it matters (by stakeholder)
+
+| You are a… | This gives you… |
+|---|---|
+| **QA engineer** | Read a Figma screen's real labels/actions → derive test conditions the AC text missed; render the frame as a reference image for a design-vs-build check. |
+| **Business analyst / PO** | Turn a design frame straight into user stories grounded in the actual screen content, not guesswork. |
+| **Dev / design-system owner** | Publish `component ↔ code` mappings so devs see your real code snippet inside Figma Dev Mode. |
+| **Teammate trying it** | Copy `.env.example` → your own `.env`, add a Figma token, done (see *Fast start*). |
+
+---
+
+## Two ways it works
+
+**1. Read designs (REST API) — the everyday workhorse.** Pull a frame's text, specs, components,
+styles, comments, or a rendered PNG. Needs only a **File-Read** token. This is what powers
+"design → user stories / test conditions" and design-vs-build QA.
+
+**2. Sync design ↔ code (Code Connect) — `@figma/code-connect`.** Publish mappings that link a
+Figma **Component** to your code component, shown in Dev Mode. Two authoring modes: parser
+`.figma.tsx` via the CLI (`figma connect publish`), or template `.figma.ts` via the Figma MCP tools
+— the reference explains which to use. Needs an Org/Enterprise plan, published Components, and (for
+the CLI path) a token with **both** File-Read *and* Code-Connect-Write scopes.
+
+> **Which do I use?** Reading a design (stories, specs, QA, images) → **REST**. Keeping a component
+> library in sync with code → **CLI**. App-screen files (plain frames, no published Components) are
+> a REST job, not a Code Connect job.
+
+---
+
+## Fast start (5 minutes)
+
+1. **Node 18+** — the CLI runs via `npx @figma/code-connect@latest` (no global install needed).
+2. **Make your own credentials file** — copy the shared template, then fill in *your* token.
+   `.env.example` is committed (placeholders only); `.env` is yours alone (gitignored):
+   ```bash
+   cp .env.example .env        # then edit .env:
+   #   FIGMA_ACCESS_TOKEN=figd_…   (Figma → Settings → Security → Personal access tokens)
+   #   FIGMA_FILE_KEY=…            (optional; the …/design/<FILE_KEY>/… segment of a Figma URL)
+   ```
+   Scopes: **File content → Read** for design reads; add **Code Connect → Write** only if you'll
+   publish mappings. The CLI needs **both**.
+3. **Check the connection:**
+   ```bash
+   set -a; . ./.env; set +a
+   curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" https://api.figma.com/v1/me   # 200 = connected
+   ```
+   *(On Windows/PowerShell, see the "Windows note" in the reference for the `.env` load equivalent.)*
+
+---
+
+## Read a screen → user stories (paste this)
+Grab a Figma frame URL, convert the node-id (`11073-1898` → `11073:1898`), and pull its text —
+those words are your requirements:
+```bash
+set -a; . ./.env; set +a
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" \
+  "https://api.figma.com/v1/files/<FILE_KEY>/nodes?ids=<NODE:ID>" | node -e '
+let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{
+  const doc=Object.values(JSON.parse(d).nodes)[0].document,out=[];
+  (function w(n){if(n.type==="TEXT"&&n.characters)out.push(n.characters.replace(/\s+/g," ").trim());(n.children||[]).forEach(w)})(doc);
+  console.log(doc.name+" — "+out.length+" text layers");out.forEach(t=>t&&console.log("  • "+t));
+});'
+```
+Then shape the output into `Description → User Story → Test Conditions` (the handoff format in
+`SKILL.md`) and hand it to `test-design`. Full endpoint list + the MCP Code Connect path are in
+[`references/figma-cli.md`](references/figma-cli.md).
+
+---
+
+## Safety, in plain terms
+
+- 🔒 **Your token stays secret.** Kept in `.env` only (gitignored), sent in the `X-Figma-Token`
+  header or `FIGMA_ACCESS_TOKEN` — never printed, logged, or placed on a command line. A token
+  pasted into a chat is compromised — rotate it.
+- ✋ **Reads are free; writes are confirmed.** REST GETs and `preview`/`parse` are read-only.
+  Anything that changes Figma — `publish` / `unpublish` / `migrate`, or posting a comment — is
+  stated first and waits for your OK.
+- 🧪 **Verified, not assumed.** Every REST endpoint and CLI command in the reference was run
+  against a live Figma tenant; the real gotchas (the two-scope 403, node-id dash-vs-colon, the
+  ~30-min image-URL expiry, Windows path traps) are documented inline.
+
+---
+
+## What's in this folder
+
+| File | For whom | What it is |
+|---|---|---|
+| [`SKILL.md`](SKILL.md) | the agent | Operating instructions: when to use REST vs CLI, connection check, guardrails |
+| `README.md` | **people** | This guide |
+| [`references/figma-cli.md`](references/figma-cli.md) | agent + humans | The full reference — CLI (install/auth/commands/authoring) **and** the REST read toolkit |
+
+Follows the same shape as the other AgenTeX integration skills (`azure-integration`,
+`jira-integration`): a `SKILL.md` plus a reference, no bundled scripts — the agent runs the CLI
+(via `npx`) and REST calls directly.
+
+---
+
+## Scope — what's in and what's out
+
+- ✅ **Read designs (REST)** — text/specs, components, styles, comments, image renders. Fully
+  verified; the primary everyday use.
+- ✅ **Code Connect (CLI)** — component↔code mappings for Dev Mode. Real, but only applies when you
+  have published **Components** and matching **code components**, plus a both-scopes token.
+- ➖ **Editing designs** — out of scope. This skill reads designs and syncs mappings; it does not
+  create or modify Figma content.
+
+Pairs with **`test-design`**: when a story carries a Figma link, that skill can hand off to this
+one to read the frame and enrich the test conditions.

--- a/skills/figma-integration/README.md
+++ b/skills/figma-integration/README.md
@@ -100,9 +100,9 @@ Then shape the output into `Description → User Story → Test Conditions` (the
 | `README.md` | **people** | This guide |
 | [`references/figma-cli.md`](references/figma-cli.md) | agent + humans | The full reference — CLI (install/auth/commands/authoring) **and** the REST read toolkit |
 
-Follows the same shape as the other AgenTeX integration skills (`azure-integration`,
-`jira-integration`): a `SKILL.md` plus a reference, no bundled scripts — the agent runs the CLI
-(via `npx`) and REST calls directly.
+Follows the same shape as the other AgenTeX integration skills (e.g. `azure-integration`): a
+`SKILL.md` plus a reference, no bundled scripts — the agent runs the CLI (via `npx`) and REST
+calls directly.
 
 ---
 

--- a/skills/figma-integration/SKILL.md
+++ b/skills/figma-integration/SKILL.md
@@ -39,14 +39,16 @@ Design ref (opt): <PNG URL from /v1/images — a visual baseline for design-vs-b
 ### Handoff targets — who consumes this
 The same output feeds different downstream skills; pick by where the work is tracked:
 - **`test-design`** (Azure DevOps) — *User Story* + *Test Conditions* → Step 2 → one linked Test
-  Case each. This is the primary tracked-work route.
+  Case each. Primary tracked-work route on ADO.
+- **`jira-integration`** (Jira/Confluence) — *User Story* → a Story (or Epic→Story hierarchy);
+  *Test Conditions* → the story's ACs; optionally publish the set to a Confluence page.
 - **`task-estimation`** — the scoped conditions/screens feed effort estimates and `[Testing]` tasks.
 - **`browser-testing`** — *Description + Test Conditions* → a `test/suite/*.md` spec (*Description*
   → intro, *Test Conditions* → **Acceptance criteria** / **Scenarios**); the **Design ref** PNG is
   the visual baseline for the run.
 
 This skill is the **producer at the front of the pipeline** — it reads the design and emits the
-block; the consumer skills above turn it into tracked work. It does not itself write to ADO.
+block; the consumer skills above turn it into tracked work. It does not itself write to Jira/ADO.
 
 ## Tool
 Setup, install, auth, and all commands live in this skill's `references/` folder. **Read the

--- a/skills/figma-integration/SKILL.md
+++ b/skills/figma-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-integration
-description: Interact with Figma from a QA/dev-handoff run two ways — (1) READ designs via the Figma REST API to pull a frame's text/specs/components/images for user stories, test conditions, design-vs-build checks, or a screenshot-diff reference (needs only a File-Read token); and (2) SYNC design↔code via Figma's official CLI `@figma/code-connect` (`figma connect`) — scaffold, preview, and publish component↔code mappings for Dev Mode. Use whenever a task needs to reach Figma (read a screen's content to derive requirements/stories, verify the built UI matches the design, render a frame as an image, or link a component library to code). Read the reference before the first Figma call.
+description: Reach Figma from a QA/dev-handoff run — read a design via the Figma REST API to derive user stories, test conditions, and design-vs-build baselines (primary), or sync design↔code via the official `@figma/code-connect` CLI (secondary). Use whenever a task needs to turn a Figma screen into requirements/tests, verify a build against the design, render a frame as an image, or publish component↔code mappings for Dev Mode.
 ---
 
 # Figma Integration
@@ -34,20 +34,19 @@ Design ref (opt): <PNG URL from /v1/images — a visual baseline for design-vs-b
 - For a **section/feature** (many screens), emit one such block **per frame** (see the reference's
   "one story per frame" recipe).
 - Include the **Design ref** PNG (`/v1/images`, ~30-min URL) when a design-vs-build baseline is
-  wanted — attach it to the executor's evidence or the Jira issue.
+  wanted — attach it to the executor's evidence or the tracked work item.
 
 ### Handoff targets — who consumes this
 The same output feeds different downstream skills; pick by where the work is tracked:
-- **`test-design`** (Azure DevOps) — *Test Conditions* → Step 2 → one linked Test Case each.
-- **`jira-integration`** (Jira/Confluence) — *User Story* → a Story (or Epic→Story hierarchy);
-  *Test Conditions* → the story's ACs; publish the set to a Confluence page.
+- **`test-design`** (Azure DevOps) — *User Story* + *Test Conditions* → Step 2 → one linked Test
+  Case each. This is the primary tracked-work route.
 - **`task-estimation`** — the scoped conditions/screens feed effort estimates and `[Testing]` tasks.
 - **`browser-testing`** — *Description + Test Conditions* → a `test/suite/*.md` spec (*Description*
   → intro, *Test Conditions* → **Acceptance criteria** / **Scenarios**); the **Design ref** PNG is
   the visual baseline for the run.
 
 This skill is the **producer at the front of the pipeline** — it reads the design and emits the
-block; the consumer skills above turn it into tracked work. It does not itself write to Jira/ADO.
+block; the consumer skills above turn it into tracked work. It does not itself write to ADO.
 
 ## Tool
 Setup, install, auth, and all commands live in this skill's `references/` folder. **Read the
@@ -62,7 +61,7 @@ command behaves unexpectedly:
 
 ## Verify the connection first
 The common path is a **read**, which needs only the File-Read scope. Confirm auth and that a file
-read works (matches the Jira/Azure connection-check pattern):
+read works (matches the `azure-integration` connection-check pattern):
 
 ```bash
 set -a; . ./.env; set +a

--- a/skills/figma-integration/SKILL.md
+++ b/skills/figma-integration/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: figma-integration
+description: Interact with Figma from a QA/dev-handoff run two ways — (1) READ designs via the Figma REST API to pull a frame's text/specs/components/images for user stories, test conditions, design-vs-build checks, or a screenshot-diff reference (needs only a File-Read token); and (2) SYNC design↔code via Figma's official CLI `@figma/code-connect` (`figma connect`) — scaffold, preview, and publish component↔code mappings for Dev Mode. Use whenever a task needs to reach Figma (read a screen's content to derive requirements/stories, verify the built UI matches the design, render a frame as an image, or link a component library to code). Read the reference before the first Figma call.
+---
+
+# Figma Integration
+
+## Role
+In the AgenTeX QA pipeline (read requirements → design tests → execute → report), this skill is a
+**producer**: you **read a Figma design and turn it into user stories + test conditions** that feed
+`test-design` and `browser-testing`. The design's real text layers — labels, states, actions,
+error messages — are requirements the AC prose often omits. This is the primary, everyday use, and
+it needs only a **File-content: Read** token (a simple REST read).
+
+Secondary — **only when a real component library exists** — this skill can also **sync design↔code**
+via Figma's official CLI `@figma/code-connect` (map a Figma Component to your code component so it
+shows in Dev Mode). That path needs published Components *and* a token with both scopes; it does not
+feed the test pipeline. App-screen designs (plain frames) are a read job, not a Code Connect job.
+
+You never edit designs. Prefer reads; confirm before any `publish`/`unpublish`.
+
+## Handoff — what this skill outputs
+Read a screen, then emit this fixed shape so the next stage consumes it directly:
+
+```
+Description:      <one line — what the screen is / does>
+User Story:       As a <role>, I want <goal>, so that <benefit>.
+Test Conditions:  - <condition 1>   (each maps 1:1 to a test-design Test Case)
+                  - <condition 2>
+Design ref (opt): <PNG URL from /v1/images — a visual baseline for design-vs-build>
+```
+- Ground every line in the design's actual TEXT layers (see the reference's extraction snippet) —
+  never invent from a frame name or from Dev Mode CSS (CSS has no actions/labels).
+- For a **section/feature** (many screens), emit one such block **per frame** (see the reference's
+  "one story per frame" recipe).
+- Include the **Design ref** PNG (`/v1/images`, ~30-min URL) when a design-vs-build baseline is
+  wanted — attach it to the executor's evidence or the Jira issue.
+
+### Handoff targets — who consumes this
+The same output feeds different downstream skills; pick by where the work is tracked:
+- **`test-design`** (Azure DevOps) — *Test Conditions* → Step 2 → one linked Test Case each.
+- **`jira-integration`** (Jira/Confluence) — *User Story* → a Story (or Epic→Story hierarchy);
+  *Test Conditions* → the story's ACs; publish the set to a Confluence page.
+- **`task-estimation`** — the scoped conditions/screens feed effort estimates and `[Testing]` tasks.
+- **`browser-testing`** — *Description + Test Conditions* → a `test/suite/*.md` spec (*Description*
+  → intro, *Test Conditions* → **Acceptance criteria** / **Scenarios**); the **Design ref** PNG is
+  the visual baseline for the run.
+
+This skill is the **producer at the front of the pipeline** — it reads the design and emits the
+block; the consumer skills above turn it into tracked work. It does not itself write to Jira/ADO.
+
+## Tool
+Setup, install, auth, and all commands live in this skill's `references/` folder. **Read the
+reference file BEFORE the first `figma connect` command in a session**, and again whenever a
+command behaves unexpectedly:
+- **`${CLAUDE_PLUGIN_ROOT}/skills/figma-integration/references/figma-cli.md`** — has both halves:
+  **(read, primary)** the Figma REST recipes — discovery (teams→projects→files), file/node reads,
+  the TEXT-layer extraction snippet for stories/conditions, images, styles, comments; and
+  **(sync, secondary)** the `@figma/code-connect` CLI — install, auth, `figma.config.json`,
+  commands, and `.figma.ts` authoring. For the read path, jump to "§Read designs via the Figma
+  REST API".
+
+## Verify the connection first
+The common path is a **read**, which needs only the File-Read scope. Confirm auth and that a file
+read works (matches the Jira/Azure connection-check pattern):
+
+```bash
+set -a; . ./.env; set +a
+[ -n "$FIGMA_ACCESS_TOKEN" ] || echo "BLOCKED: set FIGMA_ACCESS_TOKEN in .env"
+curl -s -o /dev/null -w "me:%{http_code}\n" -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" https://api.figma.com/v1/me
+# and a real file read should be 200 (404/403 = no access or missing File-Read scope):
+curl -s -o /dev/null -w "file:%{http_code}\n" -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>?depth=1"
+```
+`me:200` + `file:200` = ready to read designs. Credentials come from `.env` (gitignored):
+`FIGMA_ACCESS_TOKEN`, optionally `FIGMA_FILE_KEY`.
+
+**Only if you will `publish`/`unpublish` Code Connect** (the secondary path): first check the file
+actually has **published Components** — no components means Code Connect can't run *at all* (most
+app-screen files are this case), so don't spend time on the CLI:
+```bash
+# empty "meta.components" [] → REST-only, skip Code Connect entirely:
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>/components" \
+  | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const n=((JSON.parse(d).meta||{}).components||[]).length;console.log(n?("Code Connect possible: "+n+" published components"):"REST-only: 0 published components — Code Connect N/A")})'
+```
+The CLI path also needs the token's **Code Connect: Write** scope + Node 18+
+(`npx @figma/code-connect@latest --version`); without Write, `figma connect` 403s "Invalid scope(s)".
+
+## Rules
+- Preflight `figma connect --help` (via `npx`) before use; it's an **npm** CLI (Node 18+), not a
+  standalone binary and not installed by default — install per the reference if missing.
+- **Never print or log the token** — pass it via `FIGMA_ACCESS_TOKEN` from `.env` (or the
+  `X-Figma-Token` header for REST); never echo it or place it in argv.
+- Default to read-only (`preview`, `parse`, REST GETs). **Confirm with the user before any write** —
+  `publish`, `unpublish`, or `migrate` change what teammates see in Figma Dev Mode — and state
+  exactly what will be published/removed first.
+- In CI/non-interactive shells, use `--exit-on-unreadable-files` and the `FIGMA_ACCESS_TOKEN` env
+  var — never hardcode the token.

--- a/skills/figma-integration/references/figma-cli.md
+++ b/skills/figma-integration/references/figma-cli.md
@@ -235,6 +235,15 @@ This is the **workhorse for QA/requirements** — the Code Connect CLI authors m
 work even when the CLI is blocked. Same token in the `X-Figma-Token` header, base
 `https://api.figma.com/v1`.
 
+> **REST vs the Figma MCP for *reading* — they return different things.** The Figma MCP
+> (`get_metadata`, `get_screenshot`) gives the layer **structure** and a **screenshot** — great for
+> frame names and a visual baseline, and it needs no token (just the connector). But it does **not**
+> return the **TEXT-layer characters** (button labels, validation copy, error messages) — the exact
+> on-screen words that become requirements. For those, use the **REST `/nodes` + TEXT extraction**
+> below (needs `FIGMA_ACCESS_TOKEN`). Rule of thumb: **MCP for structure/visual, REST for the copy.**
+> Also: `get_metadata` on a whole feature/section can be huge (overflows the token limit) — read a
+> single frame with `?depth=N` or `/nodes?ids=` instead of the whole node.
+
 **Parse the Figma URL first** (both values come from it):
 `https://figma.com/design/`**`<FILE_KEY>`**`/Name?node-id=`**`<NODE-ID>`**
 - **FILE_KEY** = the segment right after `/design/`.

--- a/skills/figma-integration/references/figma-cli.md
+++ b/skills/figma-integration/references/figma-cli.md
@@ -43,6 +43,11 @@ use the `include`/`exclude` globs to find files; with no config it parses the cu
   React/React Native, HTML/Web Components (Angular, Vue), SwiftUI, Jetpack Compose, custom.
 - `label`: groups a set of mappings (e.g. per framework) — the `-l/--label` flag targets it.
 - `importPaths`: rewrites the import shown in Dev Mode (repo path → published package path).
+- **TypeScript repos** — add the Code Connect type defs to `tsconfig.json` so template files get
+  autocomplete on `figma.*` / the `instance.get*` accessors:
+  ```json
+  { "compilerOptions": { "types": ["@figma/code-connect/figma-types"] } }
+  ```
 
 ## Commands
 Verified against the live CLI. Common flags on the file-scanning commands (`publish`/`unpublish`/

--- a/skills/figma-integration/references/figma-cli.md
+++ b/skills/figma-integration/references/figma-cli.md
@@ -1,0 +1,346 @@
+# Tool: figma (`@figma/code-connect`)
+
+Figma's official CLI — the **Code Connect** tool. Read this when a task needs to link Figma
+components to code, publish/preview those links, or read a design's structure for verification.
+Official docs: https://developers.figma.com/docs/code-connect/  ·  Verified live via `npx`.
+
+> Note: Code Connect maps Figma **components ↔ code snippets** so they show in Dev Mode. It is a
+> design-system / dev-handoff tool, not a browser test runner. Use it to keep design and code in
+> sync and to read component structure; it does not execute app tests.
+
+## Preflight & install
+- Preflight: `npx --yes @figma/code-connect@latest --version` (no global install needed) and
+  `figma connect --help`.
+- Node **18+** required. Two ways to run:
+  - **No install (recommended):** `npx @figma/code-connect@latest connect <command> …`
+  - **Global:** `npm install --global @figma/code-connect@latest`, then `figma connect <command> …`
+- Verify: `figma connect --help` (or the `npx …` form).
+
+## Auth
+- Create a **personal access token** at Figma → Settings → Security → Personal access tokens,
+  with scopes: **Code Connect = Write**, **File content = Read**.
+- The CLI reads it from **`FIGMA_ACCESS_TOKEN`** (or `--token <t>`; prefer the env var — never put
+  the token on the command line). Keep values in `.env` (gitignored): `FIGMA_ACCESS_TOKEN`,
+  and optionally `FIGMA_FILE_KEY` for the file you work against. Load with `set -a; . ./.env; set +a`.
+- Token scopes matter: `publish`/`unpublish` need Code Connect **Write**; reads need File **Read**.
+
+## Config — `figma.config.json`
+The CLI auto-discovers `figma.config.json` (or pass `-c/--config`). `publish`/`unpublish`/`parse`
+use the `include`/`exclude` globs to find files; with no config it parses the current directory (or
+`--dir`).
+```json
+{
+  "codeConnect": {
+    "include": ["src/**/*.figma.tsx"],
+    "exclude": ["**/node_modules/**", "**/*.stories.tsx"],
+    "parser": "react",
+    "label": "React",
+    "importPaths": { "src/components/*": "@ui/components" }
+  }
+}
+```
+- `parser`: `react` | `html` | `swift` | `compose` | `custom` (framework). Supported frameworks:
+  React/React Native, HTML/Web Components (Angular, Vue), SwiftUI, Jetpack Compose, custom.
+- `label`: groups a set of mappings (e.g. per framework) — the `-l/--label` flag targets it.
+- `importPaths`: rewrites the import shown in Dev Mode (repo path → published package path).
+
+## Commands
+Verified against the live CLI. Common flags on the file-scanning commands (`publish`/`unpublish`/
+`parse`): `-r/--dir <dir>`, `-f/--file <files…>`, `-c/--config <path>`, `--dry-run`,
+`--exit-on-unreadable-files` (use in CI).
+
+- **Scaffold a mapping — `figma connect create <FIGMA_NODE_URL>`**  (read-then-write-file)
+  Generates a boilerplate `.figma.ts` with the component's prop accessors. Output location:
+  **`-o/--outDir <dir>`** (defaults to the current directory). **Fetches the node from Figma →
+  needs the token with BOTH scopes.**
+- **Preview — `figma connect preview [files…]`**  (read-only)
+  Renders snippets as the Figma inspect panel shows them; validates syntax (Prettier). Safe anytime.
+- **Parse — `figma connect parse [--outFile <file>]`**  (read-only)
+  Emits the JSON representation of the Code Connect files (stdout by default) for debugging/tooling.
+- **Publish — `figma connect publish` (WRITE — confirm first)**
+  Scans `include`/`exclude` for `.figma.ts`/`.figma.js`, publishes them to Dev Mode. Flags:
+  `-l/--label <l>`, `--force` (overwrite UI-created mappings), `--skip-validation`,
+  `-b/--batch-size <n>` (chunk large uploads).
+- **Unpublish — `figma connect unpublish` (WRITE — confirm first)**
+  Removes connections. Either by dir/file (matches config), **or** target one:
+  `--node <NODE_URL> --label <l>` (`--label` is required with `--node`).
+- **Migrate — `figma connect migrate` (WRITE)**
+  Converts **legacy parser-based** `.figma.tsx` (uses `figma.connect()`) → **template-based**
+  `.figma.ts` (the newer format, see "Two authoring modes" below). Flags: `--outDir <dir>`,
+  `--javascript` (emit `.figma.js`), `--batch auto|all|none`, `--include-props`.
+  Migration output is a **starting point, not finished** — commit first, write to `--outDir` (keep
+  originals), then review for: `getPropertyValue()` string comparisons (usually → `getBoolean`/
+  `getEnum`); verbose if/else from variant restrictions (often → a ternary on `example`/`imports`);
+  and unnecessary `figma.helpers.*` (drop when a prop's type is known). Verify equivalence with
+  `parse --file <path>` before/after; delete originals only once the new files parse.
+
+Global flags (all commands): `-t/--token <t>` (defaults to `FIGMA_ACCESS_TOKEN`), `-v/--verbose`,
+`-a/--api-url <url>` (custom API base), `--skip-update-check`, `-V/--version`, `-h/--help`.
+
+## Prerequisites for Code Connect (both authoring modes)
+Before publishing any mapping, all of these must hold — otherwise you hit a wall the commands
+don't explain:
+- **Figma plan:** Code Connect requires an **Organization or Enterprise** plan. **Not available on
+  Free or Professional** — publish will fail regardless of token/scopes.
+- **Published Components:** the node must be a real Figma **Component** *published to a team
+  library* (a plain frame/section can't be mapped).
+- **Token:** the CLI path needs **both** scopes (see gotcha below). The MCP path uses your Figma
+  MCP session instead of a token.
+
+## Two Code Connect authoring modes
+There are **two** ways to author mappings — pick by what's available:
+
+| Mode | Files | How | Prefer when |
+|---|---|---|---|
+| **A. CLI / parser** | `.figma.tsx` using `figma.connect()`, `figma.string()`, `figma.enum()`… | author locally → `figma connect publish` | **CI / no MCP**, or a repo of `.figma.tsx` already exists |
+| **B. MCP / template** | `.figma.ts` template files, or mappings saved straight to Figma | the **Figma MCP** tools (below) fetch component context and save mappings | **an MCP server is available** (the newer, Figma-recommended path) |
+
+**Decision rule:** *Figma MCP server available → prefer templates (Mode B). CI or no MCP →
+parser + CLI (Mode A).* The CLI sections in this file cover Mode A; the rest of this section
+covers Mode B.
+
+### Mode B — Figma MCP tools (template-based, no local CLI)
+When a `figma` MCP server is connected, these tools do Code Connect without the CLI or a token:
+- `list_file_components_for_code_connect` (fileKey) — every published component in a file + its
+  dependency graph, for planning mappings in bulk.
+- `get_code_connect_suggestions` (nodeId, fileKey) — AI-suggested code↔design links to review.
+- `get_context_for_code_connect` (nodeId, fileKey) — a component's properties, variants, and
+  descendant tree — the input for a template file.
+- `get_code_connect_map` (nodeId, fileKey) — read existing mappings (`{nodeId: {src, name}}`).
+- `add_code_connect_map` / `send_code_connect_mappings` — **WRITE** the mapping(s) to Figma
+  (single or bulk). Confirm with the user first, same as `publish`.
+
+**Template file shape** (`.figma.ts`, Mode B) differs from the parser API — it fetches context at
+author time via `figma.selectedInstance` and getters:
+```ts
+import figma from 'figma'
+const instance = figma.selectedInstance
+export default {
+  example: figma.code`<Button
+    variant=${instance.getEnum('Variant', { Primary: 'primary', Secondary: 'secondary' })}
+    disabled=${instance.getBoolean('Disabled')}
+  >${instance.getString('Label')}</Button>`,
+  imports: ["import { Button } from '@ui/button'"],
+}
+```
+Template getters: `getString` · `getBoolean('Name', { true:…, false:… })` · `getEnum` ·
+`getInstanceSwap` · `getSlot`. (Parser mode A uses the `figma.string()/boolean()/enum()` helpers
+in the authoring section below instead.)
+
+## ⚠️ Token scopes — the #1 gotcha for the CLI path (verified live)
+The CLI needs **BOTH** scopes on the token, even for `create`:
+- **File content → Read**  AND  **Code Connect → Write**
+
+A token with only one scope authenticates fine for REST (`/v1/me` → 200) but the CLI fails with:
+`Failed to get node data from Figma (403): Invalid scope(s): Please ensure that you have selected
+both the File Read scope and the Code Connect Write scope`. A REST file-read 404 (not 403) is the
+*other* symptom of a missing File Read scope. Fix: regenerate the token with both scopes checked.
+
+## Authoring a mapping — the `.figma.ts` file
+`create` scaffolds one, but you often hand-write it. Structure (React example):
+```ts
+import figma from '@figma/code-connect'
+import { Button } from './Button'   // your real code component
+
+figma.connect(Button, 'https://www.figma.com/design/<FILE_KEY>/x?node-id=<NODE_ID>', {
+  props: {
+    label:    figma.string('Label'),                 // Figma text prop  -> string
+    disabled: figma.boolean('Disabled'),             // Figma boolean prop
+    variant:  figma.enum('Variant', {                // Figma variant     -> code values
+      Primary: 'primary', Secondary: 'secondary',
+    }),
+    icon:     figma.instance('Icon'),                // nested component instance
+  },
+  example: ({ label, disabled, variant, icon }) => (
+    <Button disabled={disabled} variant={variant} icon={icon}>{label}</Button>
+  ),
+})
+```
+- First arg = the **imported code component** (drives the import statement shown in Dev Mode).
+- `node-id` in the URL uses a dash (`11073-1898`); the REST API uses a colon (`11073:1898`).
+- The node must be a real Figma **Component** (not a plain frame) for Dev Mode to attach the snippet.
+
+### Prop helpers (map Figma properties → code)
+| Helper | Maps |
+|---|---|
+| `figma.string('Prop')` | a text property → string |
+| `figma.boolean('Prop', {true:…, false:…})` | a boolean property (optional value map) |
+| `figma.enum('Prop', { VariantA: …, VariantB: … })` | a variant property → code values |
+| `figma.instance('Prop')` | a nested component instance → its own connected snippet |
+| `figma.textContent('Layer')` | a child text layer's content |
+| `figma.children('Layer')` · `figma.children(['A','B'])` · `figma.children('Icon*')` | render child instances by layer name (wildcards allowed) |
+| `figma.nestedProps('Layer', { size: figma.enum(…) })` | props of a nested instance **without** connecting it |
+| `figma.className([ 'base', figma.enum(…), figma.boolean(…) ])` | concatenate class strings, dropping undefined |
+
+### Variant restrictions (one Figma component → many code components)
+Use multiple `figma.connect` calls with a `variant` filter so each variant maps to a different
+code component:
+```ts
+figma.connect(PrimaryButton,   'https://…', { variant: { Type: 'Primary' },   example: () => <PrimaryButton/> })
+figma.connect(SecondaryButton, 'https://…', { variant: { Type: 'Secondary' }, example: () => <SecondaryButton/> })
+figma.connect(DangerButton,    'https://…', { variant: { Type: 'Danger', Disabled: true }, example: () => <DangerButton/> })
+```
+This is Code Connect's **one-to-many** mapping. CLI-published connections appear in the Figma UI
+but are **editable only via the CLI** (not in the UI).
+
+### The `figma.code` array rule (the #1 authoring footgun)
+Snippets **look like strings but are arrays underneath** (so Figma can render prop pills + inline
+errors). **Never concatenate them with `+`** — always compose inside a `figma.code` template:
+```ts
+figma.code`<MyExample/>` + iconSnippet                 // ❌ wrong — collapses the structure
+figma.code`<MyExample/>${showIcon ? iconSnippet : null}` // ✅ right
+```
+
+### Nested content — slot vs inline
+- `figma.getSlot('Content')` (template) / `figma.children('Content')` (parser) — for **freeform/
+  varied** children. Renders as a clickable label in Dev Mode; the Figma MCP can traverse into it.
+- `findConnectedInstances()` — when **every child is the same connected component** and the full
+  code should **expand inline** (e.g. a `<Select>` of list items):
+  ```ts
+  const options = instance.findConnectedInstances((n) => n.hasCodeConnect())
+    .map((child) => child.executeTemplate().example)
+  const example = figma.code`<Select>${options}</Select>`
+  ```
+  Optional 2nd arg: `{ traverseInstances: true }` to recurse, `{ path: string[] }` to restrict by
+  layer position. `metadata.nestable: false` makes a nested instance render as a link, not inline.
+
+### Batch files (many components, one code shape — e.g. icon sets)
+For large uniform sets, use a **batch** rather than one file per component:
+`*.figma.batch.ts` (the shared template) + `*.figma.batch.json` (the per-node data). **Add
+`**/*.figma.batch.json` to the config `include`** — a missing glob is the most common reason a
+batch silently doesn't publish. Full schema: the batch-files doc (linked at the bottom).
+
+## Typical workflow (test under a throwaway label first)
+Publish under a **disposable label** so a mistake is invisible to the team and removable with one
+`unpublish` — then switch to the real label.
+```bash
+set -a; . ./.env; set +a                                   # load FIGMA_ACCESS_TOKEN (both scopes)
+figma connect create "<NODE_URL>" --outDir src/components   # scaffold a .figma.ts (errors if file exists)
+# …edit: import your component, map props, write the example…
+figma connect preview src/components/Button.figma.ts        # read-only: see the Dev Mode snippet
+figma connect publish --label TEST --dry-run                # validate, publish nothing
+figma connect publish --label TEST                          # ship under a throwaway label; verify in Dev Mode
+figma connect publish --label React                         # WRITE (confirm) → live for the team
+```
+Publishing prints component names + node URLs — surface those links to the user.
+
+## Read designs via the Figma REST API (verified live)
+This is the **workhorse for QA/requirements** — the Code Connect CLI authors mappings but cannot
+*read* a design. Reads need only the **File content: Read** scope (not Code Connect Write), so they
+work even when the CLI is blocked. Same token in the `X-Figma-Token` header, base
+`https://api.figma.com/v1`.
+
+**Parse the Figma URL first** (both values come from it):
+`https://figma.com/design/`**`<FILE_KEY>`**`/Name?node-id=`**`<NODE-ID>`**
+- **FILE_KEY** = the segment right after `/design/`.
+- **NODE_ID** = the `node-id` query param — but the URL uses a **dash** (`11073-1898`) and the REST
+  API needs a **colon** (`11073:1898`). Convert before calling, or the node read is rejected.
+
+### Discovery — teams → projects → files (there is no "list all files" endpoint)
+```bash
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/teams/<TEAM_ID>/projects"      # projects in a team
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/projects/<PROJECT_ID>/files"   # files in a project
+```
+`<TEAM_ID>` = the number in a team URL (`figma.com/files/team/<TEAM_ID>/…`). You **must** name a
+team or file — the API cannot enumerate your teams from the token alone.
+
+### Read a file or a single node
+```bash
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>?depth=1"       # cheap existence/perms check — the standard file endpoint (prefer this for the connection check)
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>/meta"          # file metadata only (name/folder/creator) — real endpoint, but a distinct/lighter shape
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>?depth=2"       # pages + top-level frames (shallow = fast)
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>/nodes?ids=<NODE:ID>"  # ONE node/frame subtree (best for a single screen)
+```
+Use `?depth=N` to avoid pulling a whole huge file; use `/nodes?ids=` when you only need one screen.
+`<FILE_KEY>` = the `…/design/<FILE_KEY>/…` segment of a Figma URL.
+
+### The useful sub-resources
+```bash
+.../files/<FILE_KEY>/components   # published Components (Code Connect targets; empty on plain-frame files)
+.../files/<FILE_KEY>/styles       # color / text / effect styles (design tokens)
+.../files/<FILE_KEY>/comments     # design feedback (read as requirements)  · POST to add a comment
+.../images/<FILE_KEY>?ids=<NODE:ID>&format=png&scale=2   # render a frame → PNG URL (design reference for a screenshot diff)
+```
+The `/images` response is a JSON `{ images: { "<node>": "<url>" } }`; the URL is **short-lived
+(~30 min)** — download it immediately, don't store the link.
+
+### Extracting requirements from a design (the pattern used in practice)
+To turn a screen into user stories / test conditions, read the node and pull its **TEXT** layers
+(the words are the requirements). **Convert the node-id here:** a Figma URL gives `11073-1898`
+(dash) → REST needs `11073:1898` (colon). Example — collect all text under a node:
+```bash
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>/nodes?ids=<NODE:ID>" | node -e '
+let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{
+  const doc=Object.values(JSON.parse(d).nodes)[0].document, out=[];
+  (function w(n){ if(n.type==="TEXT"&&n.characters) out.push(n.characters.replace(/\s+/g," ").trim()); (n.children||[]).forEach(w); })(doc);
+  console.log(doc.name+" — "+out.length+" text layers"); out.forEach(t=>t&&console.log("  • "+t));
+});'
+```
+Raw Dev Mode CSS is **not** a good story/requirement source — it's positions and shapes with no
+actions or labels. Read TEXT layers via REST instead.
+
+**A SECTION or multi-frame node → one story per frame (don't flatten).** The snippet above walks a
+single node; if the link points at a **SECTION** (or any node holding several screens), iterate its
+top-level children so each frame becomes its own story instead of one undifferentiated dump:
+```bash
+curl -s -H "X-Figma-Token: $FIGMA_ACCESS_TOKEN" "https://api.figma.com/v1/files/<FILE_KEY>/nodes?ids=<NODE:ID>" | node -e '
+let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{
+  const root=Object.values(JSON.parse(d).nodes)[0].document;
+  // a SECTION/holder → one story per child frame; a single frame → just itself
+  const frames = (root.type==="SECTION"||(root.children||[]).some(c=>c.type==="FRAME"))
+    ? (root.children||[]).filter(c=>["FRAME","COMPONENT","INSTANCE"].includes(c.type)) : [root];
+  for (const f of frames){
+    const out=[]; (function w(n){ if(n.type==="TEXT"&&n.characters) out.push(n.characters.replace(/\s+/g," ").trim()); (n.children||[]).forEach(w); })(f);
+    console.log("\n## "+f.name+"  ("+out.length+" text layers)"); out.forEach(t=>t&&console.log("  • "+t));
+  }
+});'
+```
+Feature-level links (a whole section) are the normal sprint-planning input — this gives you one
+`Description → User Story → Test Conditions` block per screen.
+
+> **Windows note:** the `set -a; . ./.env; set +a` loader is **bash** (use the Bash tool). In
+> **PowerShell**, load `.env` and call the API like this:
+> ```powershell
+> Get-Content .env | ? {$_ -match '^\s*[^#].*='} | % { $k,$v = $_ -split '=',2; [Environment]::SetEnvironmentVariable($k.Trim(),$v.Trim()) }
+> curl.exe -s -H "X-Figma-Token: $env:FIGMA_ACCESS_TOKEN" https://api.figma.com/v1/me
+> ```
+
+### When to use REST vs the Code Connect CLI
+| Goal | Use |
+|---|---|
+| Read a design's text/specs → user stories, test conditions, design-vs-build checks | **REST** (this section) |
+| Render a frame as a reference image for a screenshot diff | **REST** `/images` |
+| Keep a **component library** in sync with code in Dev Mode | **Code Connect CLI** (needs real Components **and** both token scopes) |
+
+App-screen files (frames/sections, 0 published Components) are a REST job, not a Code Connect job.
+
+## Troubleshooting (Code Connect CLI)
+| Symptom | Likely cause / fix |
+|---|---|
+| File ignored on publish | `include` glob doesn't match the extension — check `.figma.ts` vs `.figma.js` vs `.figma.batch.json` |
+| 403 on publish/create | Token missing **Code Connect: Write** or **File content: Read** scope (see gotcha above) |
+| Snippet renders but props are blank | Property name in `getString`/`getEnum`/`figma.string` doesn't match Figma's exactly — **case- and space-sensitive** |
+| Nested component shows as a link, not inline code | `metadata.nestable` is `false` on the child template (or you used a slot, not `findConnectedInstances`) |
+| `create` exits with an error | Target file already exists — edit it, or pass `--outDir` |
+| Snippet structure looks mangled | String concatenation on a snippet — wrap in `figma.code` (see the array-rule) |
+| `publish` succeeds but nothing in Dev Mode | Wrong `--label`, or the node isn't a **published** Component, or the plan lacks Code Connect |
+
+## Rules
+- Preflight `figma connect --help` (via `npx`) before use; the CLI is npm-based — **not** a
+  standalone binary and **not** installed by default.
+- **Never print or log the token** — pass it via `FIGMA_ACCESS_TOKEN` from `.env`; do not echo it
+  or put it in argv (`--token` on a shared shell leaks it into history).
+- Default to read-only (`preview`, `parse`, REST GETs). Confirm with the user before any
+  **publish / unpublish / migrate** — these change what teammates see in Figma Dev Mode.
+- In CI, use `--exit-on-unreadable-files` and the `FIGMA_ACCESS_TOKEN` env var (never hardcode).
+- `--help` on any subcommand is authoritative for the installed version — flags change between
+  releases. When a task goes past this reference (full template API, batch schema, custom parsers),
+  fetch the relevant page below rather than guessing.
+
+## Official docs
+- Quickstart: https://developers.figma.com/docs/code-connect/quickstart-guide/
+- CLI reference: https://developers.figma.com/docs/code-connect/cli-reference/
+- Template files: https://developers.figma.com/docs/code-connect/template-files/
+- Template API: https://developers.figma.com/docs/code-connect/template-api/
+- Batch files: https://developers.figma.com/docs/code-connect/batch-files/
+- Config file: https://developers.figma.com/docs/code-connect/api/config-file/

--- a/skills/jira-integration/README.md
+++ b/skills/jira-integration/README.md
@@ -1,0 +1,116 @@
+# Jira & Confluence Integration
+
+> Let an AgenTeX test run **do the Atlassian paperwork for you** — file defects with screenshots
+> and video, build issue hierarchies, plan sprints, and publish the results as a Confluence page —
+> all against your real Jira/Confluence cloud, with a human confirming every change.
+
+**Status:** ✅ Verified end-to-end on a live Jira + Confluence tenant (Atlassian CLI `acli` 1.3.x).
+Read-only by default; nothing is written without explicit confirmation.
+
+---
+
+## Why it matters (by stakeholder)
+
+| You are a… | This gives you… |
+|---|---|
+| **QA engineer** | Failed test → a Jira bug filed automatically, with the screenshot and video attached and a link to the report — no manual copy-paste. |
+| **Dev / tech lead** | Defects land in your board already linked to the story/epic, in the right sprint, with reproducible evidence attached. |
+| **PM / manager** | A single Confluence page per run that embeds **live** Jira status (updates itself as issues move) — one link to share, always current. |
+| **Teammate trying it** | Copy `.env.example` → your own `.env`, add your token, one login command (see *Fast start* below). |
+
+---
+
+## What it can do
+
+**Jira** — check connectivity · read projects, issues, boards, sprints · search by JQL · build
+linked hierarchies (**Epic → Story / Task / Feature / Bug → Subtask**) · create, edit, transition,
+comment on, and link issues · create sprints and add issues to them · read fields, filters, and
+dashboards · **attach evidence** (screenshots, video, logs) to issues.
+
+**Confluence** — read and create spaces and blogs · author full page hierarchies with labels,
+comments, and access restrictions. A **copy-paste, ready-to-run** page-create recipe is included,
+so nobody has to hand-roll the boilerplate.
+
+**Jira ↔ Confluence together** — embed live Jira issues/JQL tables inside a Confluence page, and
+link Jira issues back to their Confluence pages. Both directions stay in sync automatically.
+
+---
+
+## Fast start (5 minutes)
+
+1. **Install the CLI.** One binary, direct download — no package manager. See
+   [`references/atlassian-cli.md`](references/atlassian-cli.md) for your OS.
+2. **Make your own credentials file** — copy the shared template, then fill in *your* values.
+   `.env.example` is the committed template (no secrets); `.env` is yours alone (gitignored,
+   never shared or committed):
+   ```bash
+   cp .env.example .env        # then edit .env and set the JIRA_* lines:
+   #   JIRA_SITE=your-site.atlassian.net
+   #   JIRA_EMAIL=you@example.com
+   #   JIRA_API_TOKEN=…        (create at id.atlassian.com → Security → API tokens)
+   ```
+3. **Log in** (the token is fed in securely — it never appears on the command line):
+   ```bash
+   set -a; . ./.env; set +a
+   echo "$JIRA_API_TOKEN" | acli jira auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token
+   acli jira auth status          # ✅ = you're connected
+   ```
+   Confluence is the same tool and the same credentials, with a separate one-time login
+   (`acli confluence auth login …`) — it needs Confluence enabled on your site.
+
+That's it — the agent follows the reference files from there.
+
+---
+
+## Safety, in plain terms
+
+This talks to your **real** Jira and Confluence, so it's built to be cautious:
+
+- 🔒 **Your API token stays secret.** Two files, one rule: **`.env.example`** is the shared,
+  committed template (placeholders only — safe to push); **`.env`** is *yours*, gitignored, and
+  holds the real token — never commit or share it. The token is never printed, logged, or put on a
+  command line. If a token is ever pasted into a chat, treat it as compromised and rotate it.
+- ✋ **Nothing is changed without your say-so.** Reading (view / search / list) is free; anything
+  that creates, edits, moves, or deletes is stated first and waits for your confirmation.
+- 🧪 **Every command is proven, not guessed.** Each one in the reference files was run against a
+  live site; the tricky Atlassian quirks are written down so they don't bite you.
+- ⚠️ **User administration is fenced off.** The CLI *can* deactivate/delete org user accounts, but
+  that's opt-in only, uses a different credential, and is never touched by a normal test run
+  (see *Scope* below).
+
+---
+
+## What's in this folder
+
+| File | For whom | What it is |
+|---|---|---|
+| [`SKILL.md`](SKILL.md) | the agent | Operating instructions: connection check, hierarchy/sprint rules, guardrails |
+| `README.md` | **people** | This guide |
+| [`references/atlassian-cli.md`](references/atlassian-cli.md) | agent + humans | Jira commands: install, auth, issues, hierarchy, boards, sprints, attachments |
+| [`references/confluence-cli.md`](references/confluence-cli.md) | agent + humans | Confluence: spaces, pages (REST), labels, comments, restrictions |
+| [`references/admin-cli.md`](references/admin-cli.md) | agent + humans | ⚠️ Opt-in org-admin user management — separate auth, confirm every write |
+
+It follows the same shape as the other AgenTeX integration skills (`azure-integration`): a
+`SKILL.md` plus one reference per surface, no bundled scripts — the agent runs the CLI (and, for
+the few things the CLI can't do, a documented REST call) directly.
+
+---
+
+## Scope — what's in and what's out
+
+The Atlassian CLI covers several products; this skill deliberately covers the ones a test run uses:
+
+- ✅ **Jira + Confluence** — the everyday QA surfaces. Fully covered and verified.
+- ⚠️ **Org admin** (user activate/deactivate/delete) — documented but **opt-in only**: different
+  credential, high blast radius, confirm-per-user, and never used by an automated run. Prefer
+  deactivate over delete; delete is effectively permanent.
+- ➖ **Atlassian Guard** and **Rovo Dev** — not things you'd drive from a test run; out of scope.
+
+New capabilities are added only when there's a real need, always keeping the read-first,
+confirm-before-write discipline.
+
+---
+
+<sub>Maturity note: validated across multiple live QA cycles (parallel + headed runs, with image
+and video evidence upload). Earlier reviews flagged gaps around attachments and Confluence
+authoring — all now closed and re-verified. Ready for the team to try.</sub>

--- a/skills/jira-integration/SKILL.md
+++ b/skills/jira-integration/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: jira-integration
+description: Interact with Jira from a QA/test run via the Atlassian CLI (`acli`) — login/auth, verify connectivity, read projects and issues, build linked issue hierarchies (Epic → Story/Task/Bug → Subtask), file defects, and manage boards & sprints. Use whenever a task needs to reach Jira (check the connection, look up or search issues, file a bug from a failed test, create an epic/story/subtask, plan a sprint) or when `acli` is not installed. Read the reference before the first `acli` command.
+---
+
+# Jira Integration
+
+## Role
+You connect a test run to Jira through the Atlassian CLI (`acli`, run via Bash). You use Jira
+to **support** testing — verifying connectivity, reading projects/issues, building linked issue
+hierarchies, filing or transitioning defects, and organizing work into sprints — not to
+administer the site. Prefer read-only commands; get explicit confirmation before any write
+(create / edit / transition / comment / delete, or any board/sprint change).
+
+## Tool
+Setup, install, auth, and all commands live in this skill's `references/` folder. **Read the
+reference file BEFORE the first `acli` command in a session**, and again whenever a command
+behaves unexpectedly:
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/atlassian-cli.md`** — Atlassian CLI
+  (`acli`) for **Jira**: install-if-missing (direct binary download per the official Windows guide),
+  auth (browser + API token over stdin), reading projects/issues (+ the `--json` field-shape
+  gotcha), writing issues, building a linked hierarchy with `--parent`, and managing boards &
+  sprints (including the REST fallback for adding existing issues to a sprint).
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/confluence-cli.md`** — the **same
+  `acli` binary** for **Confluence** (`acli confluence`): spaces, pages, blogs. Confluence auth is
+  separate from Jira and needs a Confluence license on the site (fails as BLOCKED otherwise);
+  pages are read-only in acli (author via the `/wiki/rest/api` REST fallback).
+- **`${CLAUDE_PLUGIN_ROOT}/skills/jira-integration/references/admin-cli.md`** — ⚠️ **opt-in, high
+  blast radius.** Org-admin user management (`acli admin user` activate/deactivate/**delete** real
+  accounts). Separate org API key (not the Jira token), every command destructive, confirm-per-user.
+  **Out of scope for automated/CI test runs** — read this ONLY when the user explicitly asks for
+  user-management automation.
+
+## Verify the connection first
+Before any read/write Jira step, confirm auth is working and do not proceed on failure:
+
+```bash
+acli --help            # installed?  (install per the reference if missing)
+acli jira auth status  # PASS = an authenticated account/site is shown
+```
+
+If not authenticated, log in with the API token over stdin (credentials from `.env`, gitignored):
+
+```bash
+echo "$JIRA_API_TOKEN" | acli jira auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token
+```
+
+## Building hierarchies & sprints
+- Jira's hierarchy is fixed: **Epic → (Story | Task | Feature | Bug) → Subtask**. Create top-down
+  and pass each child `--parent <key-from-the-previous-create>`. A **Subtask must parent to a
+  standard issue** (Story/Task/Bug), never directly to an Epic. Verify with `search --jql "parent = <KEY>"`.
+- Sprints live on a **board** — get the board id via `acli jira board search`, then
+  `acli jira sprint create --board <id> --name "…"`. acli has no "add to sprint" command; add
+  existing issues via the Agile REST API (see the reference). Subtasks inherit their parent's sprint.
+
+## Rules
+- Preflight `acli --help` before use; install per the reference if it's missing.
+- **Never print or log secrets** — API tokens, full emails, auth headers. Keep values in `.env`
+  (`JIRA_SITE`, `JIRA_EMAIL`, `JIRA_API_TOKEN`) and pass the token over stdin (acli) or via
+  basic-auth env interpolation (curl) — never echo it or place it on the command line.
+- Default to read-only (`workitem view`, `workitem search`, `project list`). **Confirm with the
+  user before any write** — create, edit, transition, comment, delete, or any board/sprint change —
+  and state exactly what will be created/changed first (writes hit live Jira and are not test data).
+- `project list` requires a flag (`--limit`/`--recent`/`--paginate`); prefer table output over
+  `--json` for reliable field values (acli nests JSON fields under `versionedRepresentations`).
+- In CI/non-interactive shells, authenticate from env vars / a secret store — never hardcode.

--- a/skills/jira-integration/references/admin-cli.md
+++ b/skills/jira-integration/references/admin-cli.md
@@ -1,0 +1,47 @@
+# Tool: atlassian-cli (`acli`) — Organization Admin  ⚠️ HIGH BLAST RADIUS
+
+**Same binary as Jira/Confluence**, but a fundamentally different surface: `acli admin` manages
+**real user accounts in your Atlassian organization**. Every `admin user` subcommand *changes a
+person's account state* — there is **no read/list command**. Treat this as a destructive tool.
+
+> Scope note: this reference exists only because user-management automation was explicitly
+> requested. It is **opt-in and confirm-before-every-write**. A routine test run must never call
+> `admin user …`. If you're here by accident, stop — use the Jira/Confluence references instead.
+
+## Separate auth — a different credential entirely
+`admin` does **not** use the Jira/Confluence API token in `.env`. It needs an **organization API
+key** tied to an **org-admin email**:
+- Create at **https://admin.atlassian.com → Settings → API keys** (org-admin privilege required).
+- Store as its own env var, e.g. `ATLASSIAN_ADMIN_EMAIL` and `ATLASSIAN_ADMIN_API_KEY` in `.env`
+  (gitignored) — **do not** reuse `JIRA_API_TOKEN`; it will not work and must not be conflated.
+- Login (key over STDIN, never argv):
+  ```bash
+  echo "$ATLASSIAN_ADMIN_API_KEY" | acli admin auth login --email "$ATLASSIAN_ADMIN_EMAIL" --token
+  acli admin auth status     # confirm the admin session
+  acli admin auth logout     # end it as soon as the task is done
+  ```
+- If not authenticated: `✗ unauthorized: use 'acli admin auth login'` — that's BLOCKED (missing
+  org API key), not a bug. Do not attempt to substitute the Jira token.
+
+## Commands — ALL destructive (confirm each, per user)
+`acli admin user` has no list/view; the four verbs each mutate managed accounts:
+
+| Command | Effect | Reversible? |
+|---|---|---|
+| `acli admin user deactivate --email <a,b>` \| `--id <id>` | Suspends the account(s) | Yes — via `activate` |
+| `acli admin user activate --email <a,b>` \| `--id <id>` | Re-enables a deactivated account | — |
+| `acli admin user delete --email <a>` \| `--id <id>` | **Deletes a managed account** | Only within the grace window via `cancel-delete` |
+| `acli admin user cancel-delete --id <id>` | Cancels a pending deletion | — |
+
+Inputs: `--email` (comma-separated), `--id` (account IDs), or `--from-file <list>`; `--json` for output.
+
+## MANDATORY guardrails for this reference
+- **Never run `admin user delete`/`deactivate` without explicit, specific per-user confirmation.**
+  State the exact accounts (emails/IDs) and the exact action, and get a "yes" for *those users*
+  before executing. Approval for one action never carries to another.
+- **No bulk/`--from-file` deletes** without the user reviewing the full list first.
+- **`delete` is effectively irreversible** (only cancellable inside Atlassian's grace window) —
+  prefer `deactivate` unless permanent removal is explicitly intended.
+- Never authenticate admin speculatively; log out (`admin auth logout`) when finished.
+- Same secret rules: org API key via STDIN only, kept in `.env`, never printed/logged/echoed.
+- This tool is **out of scope for automated/CI test runs** — interactive, human-confirmed use only.

--- a/skills/jira-integration/references/atlassian-cli.md
+++ b/skills/jira-integration/references/atlassian-cli.md
@@ -1,0 +1,144 @@
+# Tool: atlassian-cli (`acli`)
+
+Atlassian command-line tool. Read this when a task needs Jira (view/search issues, build an
+issue hierarchy, file a defect, manage sprints) or when `acli` is missing.
+Official docs: https://developer.atlassian.com/cloud/acli/  ·  Verified against acli **1.3.x**.
+
+## Preflight & install
+- Preflight: `acli --help` (verify it's installed) and `acli jira auth status` (check auth).
+- If missing, install (there is **no** winget package — download the binary directly):
+  - **Windows (per https://developer.atlassian.com/cloud/acli/guides/install-windows/):**
+    - x86-64: `Invoke-WebRequest -Uri https://acli.atlassian.com/windows/latest/acli_windows_amd64/acli.exe -OutFile acli.exe`
+    - ARM64:  `Invoke-WebRequest -Uri https://acli.atlassian.com/windows/latest/acli_windows_arm64/acli.exe -OutFile acli.exe`
+    - Move `acli.exe` into a folder on your PATH (e.g. a personal `bin`), then open a new shell.
+  - **macOS / Linux:** download the matching binary from https://developer.atlassian.com/cloud/acli/guides/ , `chmod +x acli`, move to `/usr/local/bin`.
+- Verify after install: `acli --help`.  CLI versions are supported ~6 months after release — update periodically.
+
+## Auth
+- `acli jira auth login --site <your-site>.atlassian.net --web` — interactive browser login.
+- API token (non-interactive) — the token is read from **STDIN**, never passed in argv:
+  `echo "$JIRA_API_TOKEN" | acli jira auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token`
+  - Flags: `-s/--site`, `-e/--email`, `--token` (read token from stdin), `-w/--web`.
+  - Create a token at https://id.atlassian.com/manage-profile/security/api-tokens
+  - Keep values in `.env` (gitignored): `JIRA_SITE`, `JIRA_EMAIL`, `JIRA_API_TOKEN`. Load with
+    `set -a; . ./.env; set +a`. Do NOT echo the token or place it on the command line.
+- `acli jira auth status` — show the active site/account (PASS = an authenticated account is shown).
+- `acli jira auth logout` — sign out · `acli jira auth switch` — switch between accounts.
+
+## Read — projects & issues
+- **Don't know the project key yet?** Start here: `acli jira project list --limit 100`
+  (or `--recent`) to discover keys, then use the key in every command below.
+- `acli jira project list --limit 100` — list projects. **A flag is required** — one of
+  `--limit <n>` (default 30), `--recent`, or `--paginate`; bare `project list` errors out.
+- `acli jira project view --key <KEY>` — one project's detail (flag is **`--key`**, not positional).
+- `acli jira workitem view <ISSUE-KEY>` — show one issue (table view is the most reliable).
+- `acli jira workitem search --jql "<JQL>" --limit 200` — JQL search. Useful queries:
+  - `project = SCRUM ORDER BY created ASC` — everything in a project
+  - `parent = SCRUM-5` — children of an epic/issue (verify a hierarchy)
+  - `issuetype = Epic AND summary ~ "Login"` — find an epic by name
+- **`--json` gotcha:** acli's JSON nests fields under `versionedRepresentations`, not a flat
+  `fields` object, so naive `.fields.status` parsing yields `undefined`. Prefer the default
+  **table output** for reliable field values; use `--json` only when you handle that shape.
+
+## Write — issues (confirm with the user first)
+- Create (prints the new key + URL, e.g. `✓ Work item SCRUM-5 created: …/browse/SCRUM-5`):
+  `acli jira workitem create --project <KEY> --type <Type> --summary "…" --description "…"`
+  - `--type` accepts the project's configured types (e.g. Epic, Story, Task, Feature, Bug, Subtask).
+  - `-a/--assignee <email|@me|default>`, `-l/--label a,b`, `--description-file <f>`, `--json`.
+- Edit: `acli jira workitem edit --key "KEY-1,KEY-2" --summary "…"` (also `-a`, `-d`, `-l`, `-y`).
+- Transition: `acli jira workitem transition --key "<KEY>" --status "In Progress"` — note the
+  **`--key` flag** (not a positional key); accepts a comma-separated list or `--jql`.
+- Comment: `acli jira workitem comment create --key "<KEY>" --body "…"` (`comment` is a command
+  group: `create` / `list` / `update` / `delete` / `visibility`; `--body-file` / `--editor` also work).
+- Link: `acli jira workitem link create --out <KEY> --in <KEY> --type <Type>` — `link` is a group
+  (`create` / `list` / `delete` / `type`). Link types on this site: **Blocks, Cloners, Duplicate,
+  Relates** (`acli jira workitem link type` lists them). `--out` = outward issue, `--in` = inward.
+- Assign: `acli jira workitem assign --key "<KEY>" --assignee <email|@me|default>`.
+- Clone: `acli jira workitem clone --key "<KEY>" --to-project "<KEY>"` — **`--to-project` is
+  required** (clone always targets a project; `clone --key` alone errors).
+- Watchers: `acli jira workitem watcher remove --key "<KEY>" …` · `workitem list-watchers --key "<KEY>"`
+  (uses **`--key`**, not positional; there is no `watcher add` — `watcher list` is deprecated).
+- Attachments: `acli jira workitem attachment list --key "<KEY>"` / `attachment delete`. **acli
+  cannot UPLOAD** — see "Attach evidence" below for the REST recipe (screenshots, videos, logs).
+- Also available: `archive` / `unarchive` (`--key`), `delete --key "<KEY>" --yes`, `create-bulk`.
+
+## Attach evidence to an issue (screenshots, video, logs)
+acli has **no attachment-upload** command — use the REST API. The `X-Atlassian-Token: no-check`
+header is **mandatory** (without it the upload is rejected/blocked as XSRF), and the form field
+**must** be named `file`. Verified live (returns a JSON array with the new attachment id):
+```bash
+curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" -X POST \
+  -H "X-Atlassian-Token: no-check" \
+  -F "file=@path/to/evidence.png" \
+  "https://$JIRA_SITE/rest/api/3/issue/<KEY>/attachments"
+```
+- Works for any binary — `.png`, `.webm` video, `.zip`, `.log`. Repeat `-F "file=@…"` to upload
+  several in one call. Verify with `acli jira workitem attachment list --key "<KEY>"`.
+- **Size limit:** Jira Cloud defaults to **10 MB per file**. Check first (`ls -l`) and zip large
+  evidence sets; a long regression video can exceed the cap.
+
+## Build a linked hierarchy (`--parent`)
+Jira's hierarchy is fixed: **Epic → (Story | Task | Feature | Bug) → Subtask**. Create top-down
+and pass `--parent` the key returned by the previous create:
+
+```bash
+# 1) Epic (top — no parent)
+acli jira workitem create --project SCRUM --type Epic --summary "Login"          # -> SCRUM-5
+# 2) Standard issues parented to the epic
+acli jira workitem create --project SCRUM --type Story   --parent SCRUM-5 --summary "…"   # -> SCRUM-6
+acli jira workitem create --project SCRUM --type Bug     --parent SCRUM-5 --summary "…"   # -> SCRUM-9
+# 3) Subtask parented to a STANDARD issue (NOT directly to an epic)
+acli jira workitem create --project SCRUM --type Subtask --parent SCRUM-9 --summary "…"   # -> SCRUM-10
+```
+- A **Subtask must attach to a standard issue** (Story/Task/Bug), never directly to an Epic.
+- Verify links with `acli jira workitem search --jql "parent = <KEY>"`.
+
+## Boards & sprints
+Mind the flag names — they are inconsistent across these commands (verified against acli 1.3.x):
+- `acli jira board search [--name <n>] [--project <KEY>] [--limit <n>]` — find a board and its **Id**.
+  (`board list` is a command *group*, not a lister — use `board search`.)
+- `acli jira board list-sprints --id <boardId> [--state active,closed,future]` — all sprints on a board
+  (flag is **`--id`**, the board id — not `--board`, not positional).
+- `acli jira board list-projects --id <boardId>` — projects mapped to a board.
+- `acli jira sprint create --board <id> --name "…" [--goal "…"] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`
+  — creates a sprint (starts in state `future`; prints the sprint URL/id). Here the flag **is** `--board`.
+- `acli jira sprint view --id <sprintId>` — sprint detail (flag is `--id`).
+- `acli jira sprint list-workitems --board <id> --sprint <id>` — list a sprint's issues (both required).
+- `acli jira sprint update …` — start/close or re-date a sprint · `acli jira sprint delete`.
+- **Adding existing issues to a sprint:** acli has **no** `sprint add` command. Use Jira's Agile
+  REST API (basic auth = email:token from `.env`; token never echoed). Standard issues only —
+  subtasks inherit their parent's sprint automatically and the API rejects them:
+  ```bash
+  curl -s -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+    -X POST "https://${JIRA_SITE}/rest/agile/1.0/sprint/<SPRINT_ID>/issue" \
+    -H "Content-Type: application/json" \
+    -d '{"issues": ["SCRUM-5","SCRUM-6"]}'      # HTTP 204 = success (no body)
+  ```
+
+## Fields, filters & dashboards
+- **Fields:** `acli jira field` exposes only `create` / `update` / `delete` (custom fields) —
+  there is **no list/search**, so you cannot enumerate a project's fields via acli. To read the
+  field catalog, use the REST API: `curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" "https://$JIRA_SITE/rest/api/3/field"`.
+- **Filters:** `acli jira filter list --my` or `--favourite` (one is **required**) ·
+  `acli jira filter search --name "…"` · `filter view --id <id>` · `filter update` ·
+  `filter list-columns` / `reset-columns` · `filter add-favourite` · `filter change-owner`.
+- **Dashboards:** `acli jira dashboard search [--name <n>] [--owner <email>] [--limit <n>]` —
+  the only dashboard subcommand (read-only).
+
+## Jira ↔ Confluence integration (same-tenant)
+When Jira and Confluence share one cloud site (same accountId on both `/rest/api/3/myself` and
+`/wiki/rest/api/user/current`), they integrate natively — no legacy application links
+(`/rest/applinks/...` returns 404 on cloud, which is expected):
+- **Confluence page → live Jira:** embed the `jira` macro in storage-format page body —
+  single issue: `<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">SCRUM-9</ac:parameter></ac:structured-macro>`;
+  live table: same macro with `<ac:parameter ac:name="jqlQuery">sprint = 36</ac:parameter>`.
+  Embedding it makes Confluence **auto-create a remote link back on the Jira issue**.
+- **Jira issue → Confluence page:** add a remote link —
+  `POST /rest/api/3/issue/<KEY>/remotelink` with `{object:{url,title}}`; list via `GET` on the same path.
+
+## Notes
+- `acli` is a standalone binary — **not** an npm package; install by direct download, not `npm install`.
+- Treat the API token, full email, and auth headers as sensitive — never print or log them.
+  Pass the token via `JIRA_API_TOKEN` over stdin (acli) or basic-auth env interpolation (curl) only.
+- Default to read-only (`view`, `search`, `list`); confirm before any create / edit / transition /
+  comment / delete, or any sprint/board write.

--- a/skills/jira-integration/references/atlassian-cli.md
+++ b/skills/jira-integration/references/atlassian-cli.md
@@ -102,6 +102,8 @@ Mind the flag names — they are inconsistent across these commands (verified ag
 - `acli jira board list-projects --id <boardId>` — projects mapped to a board.
 - `acli jira sprint create --board <id> --name "…" [--goal "…"] [--start YYYY-MM-DD] [--end YYYY-MM-DD]`
   — creates a sprint (starts in state `future`; prints the sprint URL/id). Here the flag **is** `--board`.
+  **`--name` must be < 30 characters** (verified) — a longer name fails with
+  `✗ Sprint name must be shorter than 30 characters.` Keep the goal/detail in `--goal`, not the name.
 - `acli jira sprint view --id <sprintId>` — sprint detail (flag is `--id`).
 - `acli jira sprint list-workitems --board <id> --sprint <id>` — list a sprint's issues (both required).
 - `acli jira sprint update …` — start/close or re-date a sprint · `acli jira sprint delete`.

--- a/skills/jira-integration/references/confluence-cli.md
+++ b/skills/jira-integration/references/confluence-cli.md
@@ -1,0 +1,112 @@
+# Tool: atlassian-cli (`acli`) — Confluence
+
+**Same binary as Jira.** `acli confluence …` is a command group of the *same* Atlassian CLI
+documented in `atlassian-cli.md` — nothing extra to install. Read this when a task needs
+Confluence (spaces, pages, blog posts). Verified against acli **1.3.x**.
+
+## Prerequisite: a Confluence license on the site
+Confluence auth is **separate from Jira** and requires Confluence to be provisioned on the site
+for the account. If the site has Jira only (common on the free Atlassian Cloud tier), Confluence
+auth fails even with a valid Jira token — this is a licensing gap, **not** a CLI/command error:
+- `acli confluence auth login …` → `✗ Error: authentication failed`
+- `curl .../wiki/rest/api/space` → `HTTP 401` + an HTML login page
+
+To enable: add the Confluence product to the Atlassian Cloud site (admin.atlassian.com), then
+authenticate. Do not treat this as a bug to work around — surface it as BLOCKED (prerequisite).
+
+## Auth (once Confluence is licensed)
+Separate login from Jira, but the **same** site + email + API token (token over STDIN, never argv):
+```bash
+echo "$JIRA_API_TOKEN" | acli confluence auth login --site "$JIRA_SITE" --email "$JIRA_EMAIL" --token
+acli confluence auth status     # PASS = authenticated account/site shown
+acli confluence auth logout     # sign out
+```
+
+## Read — spaces, pages, blogs
+- **Pick a target space FIRST (mandatory before any page/blog write).** List spaces, then resolve
+  the chosen key to the numeric id the REST page/blog calls need:
+  ```bash
+  acli confluence space list                                   # discover space keys
+  curl -s -u "$JIRA_EMAIL:$JIRA_API_TOKEN" \
+    "https://$JIRA_SITE/wiki/rest/api/space/<KEY>" | \
+    node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const s=JSON.parse(d);console.log("id:",s.id,"home:",s.homepageId||"?")})'
+  ```
+- `acli confluence space list [--type personal|global] [--keys A,B] [--expand description,homepage] [--json]`
+  — list spaces.
+- `acli confluence space view --id <spaceId> [--include-all] [--labels] [--json]` — one space's detail.
+- `acli confluence page view --id <pageId> [--body-format storage|atlas_doc_format|view] [--json]`
+  — one page (the `page` group is **read-only** in acli — only `view`).
+- `acli confluence blog list` · `acli confluence blog view --id <id>` — blog posts.
+
+## Write — spaces & blogs (confirm with the user first)
+- `acli confluence space create --key <KEY> --name "…" [--description "…"] [--alias <slug>]`
+- `acli confluence space update --key <KEY> …` · `space archive --key <KEY>` / `space restore --key <KEY>`
+- **No `space delete` in acli** (archive only). To hard-delete, `DELETE /wiki/rest/api/space/<KEY>`
+  — returns **HTTP 202** (async long-running task; the space disappears shortly after).
+- Blog: `acli confluence blog create --space-id <numericId> --title "…" --body "<p>…</p>"` — note
+  **`--space-id`** (the space's numeric id from `GET /space/<KEY>`), *not* `--space`/`--space-key`.
+  Also `--status draft`, `--private`, `--from-file`, `--from-json`. `blog list` / `blog view --id`.
+- **Pages have no create/update/delete in acli** (only `page view --id`). Author/edit page content
+  via the Confluence REST API (`/wiki/rest/api`). See the operations below.
+
+## Page operations via REST (`/wiki/rest/api`) — confirm before writing
+acli's `page` group is view-only; do all page authoring through REST. Base path is
+**`/wiki/rest/api/...`** (note the `/wiki` prefix), basic auth = email:token.
+
+| Operation | Call |
+|---|---|
+| Get space numeric id / homepage | `GET /space/<KEY>` |
+| List pages in a space | `GET /content?spaceKey=<KEY>&type=page&limit=25&expand=version` |
+| Create a page | `POST /content` with `{type:"page",title,space:{key},body:{storage:{value:"<html>",representation:"storage"}}}` |
+| **Nest under a parent** (hierarchy) | add `ancestors:[{id:"<parentId>"}]` to the create/update body |
+| **Embed a live Jira issue/JQL** | put a `jira` macro in the storage body: `<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">SCRUM-9</ac:parameter></ac:structured-macro>` (or `ac:name="jqlQuery"` for a table). Auto-creates a backlink on the Jira issue. |
+| Update a page | `PUT /content/<id>` with a **bumped** `version:{number:N+1}` + new `body` (fetch current version first) |
+| Delete (to trash) | `DELETE /content/<id>` |
+| View content (rendered/storage) | `GET /content/<id>?expand=body.storage,version,ancestors` |
+| List child pages | `GET /content/<id>/child/page?limit=25` |
+| Labels | `POST /content/<id>/label` with `[{prefix:"global",name:"qa"}]` · `GET`/`DELETE` same path |
+| Comment (footer) | `POST /content` with `{type:"comment",container:{id,type:"page"},body:{storage:{…}}}` |
+| **Page restrictions** (Confluence's "assign / permission to people") | `PUT /content/<id>/restriction` with `[{operation:"update",restrictions:{user:[{type:"known",accountId:"<id>"}]}}]` · `DELETE` to clear |
+| Current user accountId (for restrictions/mentions) | `GET /wiki/rest/api/user/current` |
+
+Body format is **storage** (Confluence XHTML); Confluence macros are `<ac:structured-macro ac:name="info|status|…">…</ac:structured-macro>`.
+
+### ⚠️ Windows UTF-8 gotcha (verified)
+Passing page HTML with non-ASCII chars (em-dash `—`, emoji, curly quotes) through
+`bash → -d '…'` on Windows corrupts the bytes → Confluence rejects it with
+`JsonParseException: Invalid UTF-8 start byte 0x97`. **Fix:** build the JSON and POST it from a
+single **Node script** using `Buffer.from(JSON.stringify(payload),"utf8")` and node's `https`
+(don't hand the content to curl `-d`, and don't rely on `/tmp` — node on Windows resolves it to
+`C:\tmp`). ASCII-only bodies are fine either way.
+
+### Runnable page-create (UTF-8-safe, copy-paste)
+Write the storage-format HTML to a file, then run this — it encapsulates the Node HTTPS +
+UTF-8 pattern so you don't reinvent it each time. Args: `<SPACE_KEY> <TITLE> <BODY_FILE> [PARENT_ID]`.
+Reads `JIRA_SITE`/`JIRA_EMAIL`/`JIRA_API_TOKEN` from the env (load `.env` first).
+```bash
+node -e '
+const https=require("https"),fs=require("fs");
+const [key,title,bodyFile,parent]=process.argv.slice(1);
+const site=process.env.JIRA_SITE, auth="Basic "+Buffer.from(process.env.JIRA_EMAIL+":"+process.env.JIRA_API_TOKEN).toString("base64");
+const o={type:"page",title,space:{key},body:{storage:{value:fs.readFileSync(bodyFile,"utf8"),representation:"storage"}}};
+if(parent) o.ancestors=[{id:parent}];
+const data=Buffer.from(JSON.stringify(o),"utf8");
+const r=https.request({host:site,path:"/wiki/rest/api/content",method:"POST",headers:{Authorization:auth,"Content-Type":"application/json","Content-Length":data.length}},x=>{let b="";x.on("data",c=>b+=c);x.on("end",()=>{const j=JSON.parse(b);console.log(x.statusCode===200?("OK "+j.id+" :: "+j.title):("ERR "+x.statusCode+" "+(j.message||b).slice(0,160)));});});
+r.write(data); r.end();
+' "SD" "My Report" "./body.html" "720898"
+```
+Update a page the same way with `method:"PUT"`, path `/wiki/rest/api/content/<id>`, and a bumped
+`version:{number:N+1}` (fetch the current version first).
+
+## Notes
+- **Windows paths with spaces / cwd persistence:** the working directory is not guaranteed to
+  persist between Bash tool calls, and a repo path containing a space (e.g. `agentex-main (1)`)
+  breaks a bare `cd` — commands fail with "No such file or directory." Re-issue `cd` with the
+  **absolute, quoted** path on every call that needs it (this is separate from the UTF-8 gotcha above).
+- Confluence REST base path is `/wiki/rest/api/...` (note the `/wiki` prefix), unlike Jira's `/rest/api/...`.
+- "Assign a page to a team/person" in Confluence = **page restrictions** (view/update permissions),
+  not a Jira-style single assignee. There is no per-page "assignee" field.
+- Same secret rules as Jira: token from `.env` (`JIRA_SITE`/`JIRA_EMAIL`/`JIRA_API_TOKEN`), over
+  stdin (acli) or basic-auth env interpolation (curl/node) — never echoed or placed in argv.
+- Default to read-only (`list`, `view`); confirm before any create / update / archive / delete /
+  restrict.

--- a/skills/test-design/SKILL.md
+++ b/skills/test-design/SKILL.md
@@ -61,6 +61,13 @@ Fetch with `--expand all` (see mechanics reference for the command and field nam
 description + acceptance criteria, extract any design link (e.g. Figma) and translation tables
 from the HTML.
 
+> **Tip — read the Figma design, don't just note the link.** If the story carries a Figma URL and
+> `FIGMA_ACCESS_TOKEN` is set, the **`figma-integration`** skill can read that frame's real text
+> layers via the Figma REST API, surfacing labels, states, and actions the AC text may omit —
+> richer input for the test conditions in Step 2. See
+> `${CLAUDE_PLUGIN_ROOT}/skills/figma-integration/references/figma-cli.md` (§Read designs via the
+> Figma REST API). Read-only; no design is modified.
+
 ## Step 2 — Identify Test Conditions
 
 Group the ACs into **test conditions**. Each test condition maps to ONE test case.

--- a/skills/test-design/templates/test-template.md
+++ b/skills/test-design/templates/test-template.md
@@ -55,3 +55,6 @@ Where the design link lives in stories (e.g. "story description, under 'Figma De
 ```
 <location>
 ```
+
+> When a story carries this link and `FIGMA_ACCESS_TOKEN` is set, the **figma-integration** skill
+> can read the frame's text layers to enrich the test conditions (see its `SKILL.md`). Read-only.


### PR DESCRIPTION
Adds two integration skills:
- jira-integration — Jira & Confluence via the Atlassian CLI (acli): file defects,
  build issue hierarchies, plan sprints, publish Confluence pages. Read-only default,
  confirm-before-write. + acli permissions in settings.example.json (read=allow, write=ask).
- figma-integration — read a Figma design → user stories & test conditions.