### PR TITLE
feat(mobile-testing): add native Android/iOS app automation via Appium

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agentex",
   "displayName": "AgenTeX",
   "version": "0.13.0",
-  "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli. Test steps can call your APIs and query your database from a user-defined integration catalog, and ask your project's knowledge base a question mid-run. On Azure DevOps it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
+  "description": "Agentic QA — skip the manual grind. AgenTeX plans and runs your tests for you (human-in-the-loop or fully autonomous) with structured evidence, a consolidated defect report, and an interactive HTML dashboard, driving a real browser via playwright-cli or a real native mobile app (Android/iOS) via Appium. Test steps can call your APIs and query your database from a user-defined integration catalog, and ask your project's knowledge base a question mid-run. On Azure DevOps it designs test cases from story ACs and links them to stories, estimates QA effort and creates [Testing] tasks, and reaches Azure resources mid-run via the az CLI.",
   "author": {
     "name": "Mohamed Elgazzar",
     "email": "mhmd.elgazzar.sqe@gmail.com"
@@ -27,6 +27,11 @@
     "test-cases",
     "api-testing",
     "database",
-    "sql-server"
+    "sql-server",
+    "appium",
+    "mobile",
+    "android",
+    "ios",
+    "native-app"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to AgenTeX are documented here.
 
+## [Unreleased]
+### Added
+- **Mobile testing** — a new `mobile-testing` skill automates native Android/iOS apps through
+  a real [Appium](https://appium.io/docs/en/latest/) session, mirroring the existing
+  browser-testing flow: sequential (human-in-the-loop) or parallel (autonomous, one
+  `mobile-qa-executor` subagent per spec file, per device/emulator).
+- `/execute-mobile-test` command, `agents/mobile-qa-executor.md` subagent, and bundled starter
+  specs in `test/mobile-suite1/`.
+- Two ways to drive an Appium session, documented in
+  `skills/mobile-testing/references/`: raw W3C WebDriver REST via `curl`
+  (`appium-server-cli.md`, no extra dependency) or the bundled `webdriverio`-based
+  `scripts/appium_client.js` wrapper (`appium-client-wrapper.md`, requires the project's own
+  `webdriverio` devDependency).
+- `skills/mobile-testing/scripts/preflight.js` / `init_run.js` / `merge_run.js` — the same
+  deterministic orchestration pattern as `browser-testing`'s scripts, adapted for
+  `mobile-sessions/`.
+- Optional `mobile` block in `environments/<env>.json` (`platformName`, `automationName`,
+  `app`/`appPackage`+`appActivity`/`bundleId`, `deviceName`, `platformVersion`, `udid`) —
+  additive, browser-only projects are unaffected. Documented in `docs/configuration.md`.
+- `docs/mobile-testing.md` and `docs/contributing/adding-a-capability.md` — the latter is a new
+  contributing guide for additions bigger than one skill (its own subagent/command/docs page),
+  using this mobile-testing addition as the worked example.
+- `settings.example.json` — `appium` and read-only `adb`/`xcrun simctl` commands pre-approved;
+  destructive device actions (`adb uninstall`, `adb reboot`, `xcrun simctl erase`, …) prompt
+  instead, matching the existing `az` destructive-action pattern. The same boundary is stated
+  explicitly in `skills/mobile-testing/SKILL.md` and `agents/mobile-qa-executor.md` — a run's
+  device footprint never goes beyond installing/launching/exercising/closing the app under test.
+
+### Changed
+- `docs/getting-started.md` and `docs/contributing/architecture.md` updated to reflect the new
+  mobile-testing capability (no longer describe `qa-executor` as the only subagent).
+
 ## [0.12.0] — 2026-08-06
 ### Added
 - **Interactive Setup Wizard** — `/init-test` now launches a local web-based setup wizard

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-8A2BE2.svg)](https://docs.anthropic.com/en/docs/claude-code)
 [![Playwright](https://img.shields.io/badge/Playwright-CLI-2EAD33.svg?logo=playwright&logoColor=white)](https://www.npmjs.com/package/@playwright/cli)
+[![Appium](https://img.shields.io/badge/Appium-Mobile-660198.svg?logo=appium&logoColor=white)](https://appium.io/docs/en/latest/)
 [![Azure DevOps](https://img.shields.io/badge/Azure%20DevOps-integration-0078D7.svg?logo=azuredevops&logoColor=white)](https://azure.microsoft.com/en-us/products/devops)
 
 AgenTeX (Agentic Test eXecution) takes manual test execution off your plate. Instead of clicking the
 same scenarios by hand, an agent plans them, drives a **real browser** via
-[`@playwright/cli`](https://www.npmjs.com/package/@playwright/cli), captures screenshot/log evidence,
+[`@playwright/cli`](https://www.npmjs.com/package/@playwright/cli) or a **real native mobile
+app** via [Appium](https://appium.io/docs/en/latest/), captures screenshot/log evidence,
 and produces a consolidated defect report — either **sequentially** (human-in-the-loop) or in
 **parallel** (autonomous, one session per spec file). It **never modifies your application code**.
 
@@ -31,6 +33,7 @@ New here? **[Getting Started](./docs/getting-started.md)** walks you through ins
 | Feature | How it works | Docs |
 |---------|--------------|------|
 | **Browser testing** | An agent plans scenarios, drives a real `playwright-cli` browser, screenshots each one, and reports defects — sequential (approve each step) or parallel (one `qa-executor` subagent per spec file). | [browser-testing](./docs/browser-testing.md) |
+| **Mobile testing** | Same flow for native Android/iOS apps, driven through a real [Appium](https://appium.io/docs/en/latest/) session (raw WebDriver REST or a bundled `webdriverio` wrapper) — sequential or parallel (one `mobile-qa-executor` subagent per spec file, per device/emulator). | [mobile-testing](./docs/mobile-testing.md) |
 | **API & DB steps** | `api:` / `db:` scenario steps run **only** the named, parameterized requests/queries in your `integration/` catalog — the agent never composes its own SQL or HTTP; DDL is refused. | [api-db-steps](./docs/api-db-steps.md) |
 | **Ask the KB** | `kb:` steps (or `/ask-kb`) query your project's KB Ask API for advisory context — informs testing, **never** used as PASS/FAIL evidence. | [ask-kb](./docs/ask-kb.md) |
 | **Optimize login** | Pay a web app's login once per session: drive it live, verify by landmark (never by URL), save the browser session, and reload it into a fresh browser to continue. | [optimize-login](./docs/optimize-login.md) |
@@ -52,6 +55,7 @@ Run a parallel regression against https://example.com from the specs in test/sui
 
 # Slash commands:
 /execute-test https://example.com
+/execute-mobile-test suite1
 /estimate-story 12345 12346
 /design-test 12345
 /ask-kb acme-store: how does the checkout flow work?

--- a/agents/mobile-qa-executor.md
+++ b/agents/mobile-qa-executor.md
@@ -1,0 +1,104 @@
+---
+name: mobile-qa-executor
+description: Executes a single QA test specification against a native mobile app in an isolated Appium session (one device/emulator) and returns a defect report. Dispatched by the mobile-testing orchestrator (one subagent per test file / device session). Never modifies application code.
+tools: Bash, Read, Write, Glob, Grep
+---
+
+You are a QA test executor for a native mobile app (Android/iOS). You run the test
+specification given to you below to completion, against an isolated Appium session on your
+own device/emulator, and return a defect report. You do not modify application code. You
+execute ONLY the scenarios provided — nothing else.
+
+=== PARAMETERS (injected by the orchestrator) ===
+SESSION:        {{SESSION}}
+ENVIRONMENT:    {{ENVIRONMENT}}            # active environment name ("" for legacy projects)
+MOBILE_CAPS:    {{MOBILE_CAPS}}            # resolved `mobile` block from environments/<ENVIRONMENT>.json (platformName, automationName, app/appPackage+appActivity/bundleId, deviceName, platformVersion, udid)
+TEST_DATA:      {{TEST_DATA}}              # defaults + users JSON from environments/<ENVIRONMENT>.json ("" if none)
+WORKING_DIR:    {{WORKING_DIR}}
+SESSION_DIR:    {{SESSION_DIR}}            # e.g. executions/execu_<ts>/mobile-sessions/{{SESSION}}
+TEST SPECIFICATION:
+{{TEST_SPEC}}
+=== END PARAMETERS ===
+
+APPIUM SESSION
+- Before your first action, confirm an Appium server is reachable (`npx appium server`
+  already running, default `http://127.0.0.1:4723`) and start one if not, redirecting its
+  output to `{{SESSION_DIR}}/logs/appium-server.log`.
+- CRITICAL ISOLATION: this session targets ONE device/emulator only — never touch another
+  agent's device or session. Build the W3C capabilities payload from MOBILE_CAPS (see
+  `appium-server-cli.md`'s capability table) and write it to
+  `{{SESSION_DIR}}/caps.json` before creating the session.
+- Drive the session using EITHER approach documented in the mobile-testing skill (read the
+  relevant reference file before the first use in this session):
+  - Raw WebDriver REST via `curl` — `${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/references/appium-server-cli.md`.
+  - The bundled wrapper — `node ${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/scripts/appium_client.js <subcommand> ...`
+    (requires `webdriverio` installed in WORKING_DIR) — mechanics in
+    `${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/references/appium-client-wrapper.md`.
+  Pick whichever the project already uses; default to raw REST if neither is established.
+- Re-fetch the page source / re-find elements after every navigation or app-state change —
+  element ids are not stable across screens.
+
+WHERE TO SAVE EVIDENCE (your session slice only)
+- Screenshots -> `SESSION_DIR/screenshots/<scenario>.png`. Capture one on every scenario
+  (PASS and FAIL). Use descriptive names (sX-<what>.png).
+- Logs -> `SESSION_DIR/logs/<scenario>.log` — Appium server output, plus `adb logcat` (Android)
+  or `xcrun simctl spawn booted log stream` (iOS) captures for the scenario window when
+  something looks wrong.
+
+TEST_DATA is your test input (users, default OTP/password). A `{ "envSecret": "NAME" }` value =
+read `NAME` from the project's `.env` at use time; never print or log it.
+
+INTEGRATION STEPS (`api:` / `db:` in the spec)
+- `api:` steps → the **api-integration** skill; `db:` steps → the **db-integration** skill
+  (read the skill + its reference before the first such step). Execute via the bundled runner:
+    node ${CLAUDE_PLUGIN_ROOT}/skills/api-integration/scripts/run_api.js --entry <file>.<request> --param k=v --expect-status 200 --log {{SESSION_DIR}}/logs/<scenario>-<entry>.log
+    node ${CLAUDE_PLUGIN_ROOT}/skills/db-integration/scripts/run_db.js --entry <file>.<query> --param k=v --expect-rows 1 --log {{SESSION_DIR}}/logs/<scenario>-<entry>.log
+- Pass `--env {{ENVIRONMENT}}` to `run_db.js` / `run_api.js` when ENVIRONMENT is non-empty, so
+  DB/API hit the same environment as the app.
+- The runner executes ONLY entries defined in the project's `integration/*.json` catalog and
+  prints PASS/FAIL/BLOCKED as JSON (exit 0/1/2). BLOCKED = missing definition/param/env —
+  report it verbatim; never compose your own SQL or HTTP request to work around it.
+- The runner writes the evidence log itself; an expectation mismatch is a FAIL defect with
+  that log as evidence.
+- Never print secret values (tokens, passwords) — they come from env vars only.
+
+KB QUESTIONS (`kb:` in the spec)
+- `kb:` steps ask the project's knowledge base a natural-language question via the **ask-kb**
+  skill (read the skill + `references/kb-ask-api.md` before the first such step). Execute via
+  the bundled runner:
+    node ${CLAUDE_PLUGIN_ROOT}/skills/ask-kb/scripts/ask_kb.js --question "<text>" [--project <id>] --log {{SESSION_DIR}}/logs/<scenario>-kb.log
+  Step syntax: `kb: <question>` uses the default project from `agentex.config.json`;
+  `kb:<project>: <question>` overrides it (pass the project as `--project`).
+- Prints {"result":"OK|NOT_COVERED|BLOCKED", ...} as JSON (exit 0 OK/NOT_COVERED, 2 BLOCKED).
+  OK → read the `answer` as advisory context. NOT_COVERED → treat as "not documented in the KB".
+  BLOCKED → report the reason verbatim; never compose your own request to work around it.
+- A KB answer is ADVISORY CONTEXT ONLY — never evidence. Do NOT turn a `kb:` result into a
+  PASS/FAIL verdict or fold it into the scenario tally.
+
+EXECUTION RULES
+- Execute the scenarios in the TEST SPECIFICATION in the order written.
+- If the spec marks scenarios as a stateful chain, keep them strictly sequential in this one
+  session; otherwise treat them as independent steps.
+- Skip auth-gated actions: no real signup / login / a real purchase. NEVER use real personal
+  data — use disposable values (e.g. qa.tester@example.com). Validation-only checks are
+  allowed.
+- Never read or print secrets.
+- Never run a destructive device command against your device/emulator (`adb uninstall`,
+  `adb shell pm clear`, `adb reboot`, `adb root`, `xcrun simctl erase`, or similar) — your
+  footprint is limited to installing/launching/exercising/closing the session for the app
+  under test.
+- For any "success" UI, verify the element is actually present/visible via `find`/`source` —
+  do not assume text merely exists in the accessibility tree means it's the visible state.
+- Teardown: close the Appium session (`close-session` / `DELETE /session/<id>`) when finished,
+  even on failure, so the device/emulator is released for the next run.
+
+OUTPUT (your final message only — it is consumed by the orchestrator, not a human):
+- A heading naming the test you ran and the device/platform used.
+- Per scenario: PASS / FAIL, observed vs expected, screenshot path, log notes.
+- `kb:` steps are reported as an advisory note (the KB answer, or "not covered in the KB"),
+  never as a scenario PASS / FAIL and never counted in the final pass/fail tally.
+- A defect list, each: Title / Steps to reproduce / Expected vs Actual /
+  Severity (Critical|High|Medium|Low) / Evidence.
+- BUG EVIDENCE: an explicit list of screenshot paths (under SESSION_DIR/screenshots/) that
+  prove each defect, so the orchestrator can copy them into the run's bugs/ folder.
+- A final one-line tally: "<n> pass / <m> fail, <k> defects".

--- a/commands/execute-mobile-test.md
+++ b/commands/execute-mobile-test.md
@@ -1,0 +1,41 @@
+---
+description: Execute tests against a native mobile app (Android/iOS), optionally from a named suite folder (e.g. suite2/). Sequential (human-in-the-loop) by default; say "parallel" for an autonomous run.
+---
+
+Use the **mobile-testing** skill to test the app described below.
+
+Target / scope: $ARGUMENTS
+
+**Suite folder (if named in the arguments):**
+- The arguments may name a suite folder, e.g. `suite2/`, `test/mobile-suite2/`, or "run
+  suite2". Resolve a bare name like `suite2/` to `./test/mobile-suite1/` (first suite) or
+  `./test/mobile-<name>/` for anything else named. Run ONLY the spec files in that folder (one
+  `mobile-qa-executor` / device session per file in parallel mode).
+- If the named suite folder doesn't exist yet, create it and seed it with a starter spec
+  copied from `${CLAUDE_PLUGIN_ROOT}/test/mobile-suite1/`, tell the user to adapt it, then
+  continue.
+- If no suite is named, use the specs the user points at, or default to
+  `./test/mobile-suite1/`.
+
+**Environment (if named in the arguments):**
+- "on uat" / "env uat" selects `environments/uat.json` as the active environment;
+  otherwise the project's `defaultEnvironment` applies. An environment with no file is an
+  error — list `environments/` and stop. The active environment's `mobile` block supplies the
+  app path/package and device capabilities — there is no legacy fallback for mobile targets,
+  so ask the user if it's missing rather than guessing.
+
+**Before running:**
+- If the current project has no `test/mobile-suite1/` directory (or it has no spec files),
+  scaffold a starting point first — copy the bundled samples from
+  `${CLAUDE_PLUGIN_ROOT}/test/mobile-suite1/` into `./test/mobile-suite1/` and ensure
+  `./executions/` exists, tell the user they're editable examples, then continue.
+- If `test/mobile-suite1/` already has the user's own specs, skip the scaffold and use theirs.
+
+- If no mode is stated, use **sequential** mode (stop at each checkpoint for approval).
+- If the request says parallel / fast / regression / autonomous, use **parallel** mode and
+  dispatch one `mobile-qa-executor` subagent per test file — but only up to the number of
+  devices/emulators actually available; confirm that count first.
+- Run `node ${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/scripts/preflight.js` before the first
+  device action, and read `references/appium-server-cli.md` (or
+  `references/appium-client-wrapper.md` if the project already uses the bundled wrapper)
+  before driving the app.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ quick tour.
 | [Using Claude Code](./using-claude-code.md) | New to Claude Code itself? Start here — typing requests, slash commands, approving actions. |
 | [Getting Started](./getting-started.md) | Install → browser driver → `/init-test` → permissions → first run. |
 | [Browser Testing](./browser-testing.md) | The core flow — sequential vs. parallel modes, writing specs, output layout. |
+| [Mobile Testing](./mobile-testing.md) | Native Android/iOS app testing via Appium — sequential vs. parallel modes, capabilities, writing specs. |
 | [API & DB Steps](./api-db-steps.md) | Catalog-only `api:` / `db:` steps inside test scenarios. |
 | [Ask the Knowledge Base](./ask-kb.md) | `kb:` steps and the `/ask-kb` command (advisory only). |
 | [Optimize Login](./optimize-login.md) | Pay a web app's login cost once per session instead of once per test. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ Fill them in:
 | `users` | Test accounts keyed by a descriptive handle (`valid_user`, `expired_user`, …) that specs refer to ("login as expired_user"). Fields free-form: `phone`, `role`, `idNumber`, `password`, `notes`, … A user without `password` uses `defaults.password`. |
 | `db` | `server`, `port`, `name`, `user`, `password` — for cataloged `db:` steps. |
 | `api` | `baseUrl`, `token` — for cataloged `api:` steps. |
+| `mobile` | `platformName`, `automationName`, `app` (or `appPackage`+`appActivity` / `bundleId`), `deviceName`, `platformVersion`, optional `udid` — the Appium target for [mobile testing](./mobile-testing.md). Optional; browser-only projects can omit it entirely. |
 
 Selecting the environment at run time: "run on uat" / `env: uat` in a spec →
 `environments/uat.json`; otherwise `defaultEnvironment`. Naming an environment
@@ -70,8 +71,9 @@ fallback.
 Plugin manifests can't ship permission rules. Copy the `permissions` block from
 [`settings.example.json`](../settings.example.json) into your project's
 `.claude/settings.json` (merge with anything already there). This pre-approves the
-safe `playwright-cli` (and `az` / `curl` / `sqlcmd`) commands and denies secret
-reads / destructive actions.
+safe `playwright-cli` (and `az` / `curl` / `sqlcmd` / `appium`) commands outright, gates the
+read-only `adb`/`xcrun simctl` commands the same way, prompts before destructive `adb`/`xcrun`
+actions (uninstall, reboot, erase), and denies secret reads / destructive actions.
 
 ## Secret-handling rules
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -8,6 +8,7 @@ Documentation for anyone building or extending the plugin itself — as opposed 
 | [Claude Code 101](./claude-code-101.md) | Plugins, skills, commands, subagents — from zero. |
 | [Architecture](./architecture.md) | How AgenTeX composes those primitives: SKILL.md/references split, deterministic scripts, execution output, the qa-executor subagent. |
 | [Adding a Skill](./adding-a-skill.md) | Full worked example — build a toy skill end to end. |
+| [Adding a Capability](./adding-a-capability.md) | Checklist for something bigger than one skill — its own subagent, command, and docs page (real example: `mobile-testing`). |
 | [Conventions](./conventions.md) | Naming, the no-employer-data rule, secrets, catalog-only execution. |
 | [Testing](./testing.md) | Running and writing script tests. |
 | [PR Workflow](./pr-workflow.md) | Fork → branch → PR, what's checked on review. |

--- a/docs/contributing/adding-a-capability.md
+++ b/docs/contributing/adding-a-capability.md
@@ -1,0 +1,103 @@
+# Adding a Capability
+
+[Adding a Skill](./adding-a-skill.md) walks through a small, single-script skill end to end.
+This page is for something bigger: a whole new **part** of AgenTeX — its own driven-tool, its
+own subagent, its own command, its own docs page — the way `browser-testing` /
+`qa-executor` / `/execute-test` fit together. Use it as a checklist when a change is more than
+"one skill, one script."
+
+The real (non-toy) worked example for this page is the **mobile-testing** capability — Appium
+support alongside the existing browser-testing flow. Every file category below names its
+mobile-testing counterpart so you can read the actual files instead of a synthetic example.
+
+## Checklist
+
+1. **Confirm it's capability-sized, not skill-sized.** If it's one deterministic script behind
+   one judgment call, you want [Adding a Skill](./adding-a-skill.md) instead — don't build the
+   scaffolding below for something that small (see
+   [Conventions](./conventions.md#shared-reference-rule) on avoiding premature structure).
+
+2. **Name it** — noun-style skill, verb-style command, exactly like a regular skill (see
+   [Conventions](./conventions.md#naming)). A capability with its own driven tool usually also
+   gets its own subagent name, distinct from `qa-executor` if the driving mechanics genuinely
+   differ (isolation model, evidence shape, tool commands) — e.g. `mobile-qa-executor` alongside
+   `qa-executor`, not a flag bolted onto the existing one.
+
+3. **`skills/<name>/SKILL.md`** — judgment layer, same shape as any skill: role, target/config
+   resolution, tools pointer, execution output layout, modes, defect format, rules. Model it
+   directly on the closest existing skill rather than inventing a new shape — `mobile-testing`
+   copies `browser-testing`'s structure almost verbatim, changing only what's mechanically
+   different (device sessions instead of browser sessions, capability-based target resolution
+   instead of a URL).
+
+4. **`skills/<name>/references/*.md`** — one file per distinct tool/mechanism the skill can
+   drive with. It's fine to document more than one way to do the same job side by side (e.g.
+   `appium-server-cli.md` for raw WebDriver REST vs `appium-client-wrapper.md` for the bundled
+   script) — `SKILL.md` should say which to read before which action, and let the agent (or the
+   project's existing setup) pick.
+
+5. **`skills/<name>/scripts/`** — reuse the existing orchestration scripts' *shape*, not their
+   code, for anything mechanical: a `preflight.js` that probes every tool the capability needs
+   in one call, an `init_run.js` that scaffolds the execution tree in one call, a `merge_run.js`
+   that copies bug evidence in one call. Anything genuinely new and non-trivial (like
+   `appium_client.js`, a driver wrapper) needs a `.test.js` per
+   [Testing](./testing.md) — trivial fs/probe scripts (mirroring `preflight.js`/`init_run.js`/
+   `merge_run.js`) don't.
+   - **No bundled npm dependencies.** The plugin ships zero npm packages of its own — every
+     script uses only Node built-ins (or global `fetch`). If a capability's driver needs a
+     real npm client library (like `webdriverio`), it must be the **consumer's** own
+     devDependency, resolved dynamically from `process.cwd()` at run time
+     (`require.resolve('<pkg>', { paths: [process.cwd()] })`), with a `BLOCKED` result and
+     install instructions when it's missing — see `appium_client.js`.
+
+6. **A dedicated subagent**, if the capability has its own isolated-session model (own
+   `agents/<name>-qa-executor.md` if the isolation/evidence mechanics genuinely differ from the
+   existing one; otherwise reuse `qa-executor.md`). Keep the injected-parameters block, tool
+   commands, evidence paths, and output contract in the same shape as the existing subagent so
+   the orchestrating skill's dispatch logic stays consistent.
+
+7. **`commands/<verb>.md`** — thin entrypoint, same pattern as any command (suite-folder
+   resolution, environment resolution, mode selection, a pointer to read the relevant
+   reference before the first tool use). See `commands/execute-mobile-test.md` next to
+   `commands/execute-test.md`.
+
+8. **Reuse tool-agnostic skills as-is.** Step types like `api:` / `db:` / `kb:` aren't
+   browser-specific — the mobile-testing skill and subagent call `api-integration` /
+   `db-integration` / `ask-kb` exactly as browser-testing does, no duplication (see
+   [Conventions](./conventions.md#shared-reference-rule)).
+
+9. **If the config shape needs to grow** (a new kind of target beyond `portalUrl`), add it as
+   a new optional block in `environments/<env>.json` rather than a parallel config file — see
+   the `mobile` block added alongside `db`/`api`. Document it in `docs/configuration.md` and
+   reflect it in `templates/environments/qa.json`. Never break existing (browser-only)
+   projects — the new block must be optional and additive.
+
+10. **`docs/<name>.md`** — user-facing doc mirroring the closest existing one (walkthroughs,
+    spec-writing guide, quick reference table, setup snippet, reference pointers). See
+    `docs/mobile-testing.md` next to `docs/browser-testing.md`.
+
+11. **Wire it up everywhere a skill would, plus:**
+    - Row in `docs/README.md`'s table and the root `README.md` feature table (a new capability
+      this size usually also earns a badge next to the existing ones).
+    - `CHANGELOG.md` entry under `[Unreleased]`.
+    - `settings.example.json` — allow entries for the capability's new CLI tools, mirroring
+      the existing `playwright-cli`/`az`/`curl`/`sqlcmd` entries.
+    - `.claude-plugin/plugin.json` — new keywords, and update the top-level `description` if
+      the capability is a first-class feature (not just an internal helper).
+    - Bundled sample specs under `test/<name>-suite1/` if the capability runs test specs, and a
+      pointer to them from `test/README.md`.
+
+## Recap
+
+| File | Layer |
+|------|-------|
+| `skills/<name>/SKILL.md` | judgment |
+| `skills/<name>/references/*.md` | mechanics, one file per tool/mechanism |
+| `skills/<name>/scripts/*.js` (+ `.test.js` for non-trivial ones) | deterministic orchestration + drivers |
+| `agents/<name>-qa-executor.md` | isolated per-session execution (only if mechanics differ from the existing subagent) |
+| `commands/<verb>.md` | thin entrypoint |
+| `docs/<name>.md` | user-facing walkthrough |
+| `docs/README.md` / root `README.md` / `CHANGELOG.md` / `plugin.json` / `settings.example.json` | wiring |
+
+Next: [Conventions](./conventions.md) for the naming/security rules this checklist assumes, or
+[PR Workflow](./pr-workflow.md) to open the change.

--- a/docs/contributing/adding-a-skill.md
+++ b/docs/contributing/adding-a-skill.md
@@ -236,3 +236,5 @@ be:
 
 Next: [Conventions](./conventions.md) for the naming/security rules this example already
 followed, or [Testing](./testing.md) for how to run and write script tests like the one above.
+For something bigger than one skill — its own subagent, command, and docs page — see
+[Adding a Capability](./adding-a-capability.md).

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -9,7 +9,8 @@ predictable.
 ```text
 skills/       one folder per capability (SKILL.md + references/ + scripts/ + templates/)
 commands/     thin slash-command entrypoints ($ARGUMENTS -> skill)
-agents/       subagent definitions (currently: qa-executor.md)
+agents/       subagent definitions (one per isolated-session executor, e.g. qa-executor.md,
+              mobile-qa-executor.md)
 docs/         user-facing feature docs (this contributing/ subfolder is the exception)
 test/         sample specs scaffolded by /init-test
 executions/   NOT shipped in the plugin — output folder created in the consumer's project
@@ -82,6 +83,8 @@ of `mkdir`s — see [testing.md](./testing.md) for how scripts like this get tes
 
 **Example:** `browser-testing/SKILL.md`'s parallel mode — ~6–8 sessions run concurrently, the
 rest queue automatically; the main agent then merges every report into one `report.md`/`bugs/`.
+`mobile-testing/SKILL.md` follows the identical dispatch/merge shape with `mobile-qa-executor`,
+just bounded by available devices/emulators instead of CPU/RAM.
 
 **Pros/cons:** + real concurrency, isolated evidence per session — but needs a merge step to
 combine results.
@@ -91,3 +94,5 @@ combine results.
 - [Conventions](./conventions.md) — naming, the no-employer-data rule, secrets, the
   catalog-only principle.
 - [Adding a Skill](./adding-a-skill.md) — build a toy skill end to end using everything above.
+- [Adding a Capability](./adding-a-capability.md) — for something bigger than one skill: its
+  own subagent, command, and docs page.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -19,7 +19,12 @@ fixtures file.
 
 **Example:** `skills/ask-kb/scripts/ask_kb.test.js` (happy path, config precedence,
 `404`/`401`/`429`, retries, secret headers); the smaller `check_url.test.js` built in
-[Adding a Skill](./adding-a-skill.md).
+[Adding a Skill](./adding-a-skill.md). For a script whose real dependency is optional and
+resolved from the *caller's* project (see
+[Adding a Capability](./adding-a-capability.md#checklist) on that pattern),
+`skills/mobile-testing/scripts/appium_client.test.js` shows the shape: write a minimal fake
+module into a temp `node_modules/` so the `BLOCKED`/argument-validation paths are provable
+without the real dependency, a live server, or a device.
 
 **Pros/cons:** + catches regressions in safety rules, no framework overhead — but one more
 file to write per script.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,9 +78,16 @@ executions/execu_<timestamp>/
   into `.claude/settings.json`
 - Run: `/execute-test <url>`
 
+## Optional: testing a native mobile app instead
+
+Everything above scaffolds the **browser** flow. If your target is a native Android/iOS app
+instead (or as well), see [Mobile Testing](./mobile-testing.md) for the equivalent setup
+(`appium` + a platform driver instead of `playwright-cli`) and `/execute-mobile-test`.
+
 ## Next steps
 
 - [Browser Testing](./browser-testing.md) — sequential vs. parallel modes, writing your own specs.
+- [Mobile Testing](./mobile-testing.md) — the same flow for native Android/iOS apps, via Appium.
 - [Configuration](./configuration.md) — the three config files (`config/project.json`,
   `environments/<env>.json`, `.env`) and secret handling.
 - [docs/](./README.md) — the full feature reference.

--- a/docs/mobile-testing.md
+++ b/docs/mobile-testing.md
@@ -1,0 +1,140 @@
+# Mobile Testing
+
+The native-app counterpart to [Browser Testing](./browser-testing.md): instead of clicking
+through an Android/iOS app by hand, you describe what to test and Claude drives it for you
+through a real [Appium](https://appium.io/docs/en/latest/) session — taking screenshots,
+watching the device log, and reporting back what passed and what didn't. It never touches your
+application's code — only test artifacts get written.
+
+## Walkthrough: your first run (sequential)
+
+You type something like:
+
+> Test the login screen of our Android app — happy path plus wrong password and empty fields.
+
+Here's what happens, step by step:
+
+1. **Plan** — Claude restates what it understood (app, platform, device) and proposes a
+   numbered list of scenarios. It stops here — nothing runs yet until you approve.
+2. **Drive** — once you approve, Claude starts (or reuses) an Appium session against your
+   configured device/emulator and runs each scenario one at a time, taking a screenshot
+   whether it passes or fails, and watching the device log (`adb logcat` / simulator log) for
+   crashes or unexpected errors — these count as defects even if the screen looks fine.
+3. **Checkpoint** — after each scenario, Claude reports pass/fail with evidence and pauses
+   before moving to the next one, so you can stop or redirect at any point.
+4. **Report** — at the end, everything is written to a new `executions/execu_<timestamp>/`
+   folder: a summary (`report.md`), an interactive dashboard (`extent-report.html`), and the
+   screenshots/logs backing up every result.
+
+## Walkthrough: a full regression (parallel)
+
+For a bigger run — many spec files, no need to babysit each one — ask for it explicitly:
+
+> Run a parallel regression against our Android app from the specs in `test/mobile-suite1/`.
+
+This time Claude doesn't stop for approval at each step. It spins up one independent Appium
+session **per spec file, per available device/emulator**, then merges every session's results
+into one final report when they're all done.
+
+**Mobile concurrency is bounded by real devices, not CPU/RAM** — unlike browser-testing's
+cheap headless Chromium instances, each mobile session needs its own physical
+device/emulator/simulator. Confirm how many are actually provisioned before asking for a
+parallel run; often that's 1-2, not 6-8.
+
+**One spec file = one device session** — so keep a flow that depends on earlier steps (like
+login → action → assert) together in a single file rather than splitting it across files.
+
+## Writing your own specs
+
+A spec is a markdown file: the app under test, what "correct" looks like, and a numbered list
+of scenarios, written in plain language — same shape as a browser-testing spec, adapted for a
+native app (no URLs; elements are found by accessibility id / resource id rather than CSS
+selectors):
+
+```markdown
+# Spec: Login validation
+
+App under test: (path to .apk/.ipa, or installed appPackage/bundleId — see environments/<env>.json)
+Type: login / validation — no real account is created
+
+## Acceptance criteria
+- A valid disposable test user reaches a visible logged-in state.
+- Invalid input is rejected with a specific, visible error; the app must not proceed.
+
+## Scenarios
+1. **Happy path** — log in as a disposable test user; expect the home screen's landmark
+   element to become visible.
+2. **Wrong password** — expect a visible "invalid credentials" error, still on login.
+3. **Empty fields** — expect an inline "required" error on each field.
+
+## Notes
+- Screenshot every scenario (pass and fail).
+- Treat any app crash or unexpected device-log error as a defect even if the UI looks fine.
+```
+
+Start from the samples in [`test/mobile-suite1/`](../test/mobile-suite1/) — `/execute-mobile-test`
+copies them into your project automatically on first run. To add more coverage, drop another
+`.md` file next to them; in parallel mode each becomes its own device session.
+
+## Configuring a target app/device
+
+Mobile targets live in the `mobile` block of `environments/<env>.json` (alongside the existing
+`portalUrl`/`db`/`api` blocks used by browser testing) — see
+[Configuration](./configuration.md#environmentsenvjson):
+
+```json
+"mobile": {
+  "platformName": "Android",
+  "automationName": "UiAutomator2",
+  "app": "/absolute/path/to/app.apk",
+  "deviceName": "emulator-5554"
+}
+```
+
+There's no legacy `.env`-only fallback for mobile targets (unlike `QA_TARGET_URL` for
+browser testing) — an environment file with no `mobile` block means Claude asks you for the
+app path and device capabilities rather than guessing.
+
+## Quick reference
+
+| Mode | Trigger | Behavior |
+|------|---------|----------|
+| **Sequential** (default) | A natural-language request or `/execute-mobile-test <scope>` | Human-in-the-loop. Claude pauses for your approval at each checkpoint. Best for exploratory / first-run testing. |
+| **Parallel** (autonomous) | "Run a parallel regression … from the specs in `test/mobile-suite1/`" | Spawns one `mobile-qa-executor` subagent per spec file, each on its own device/emulator, then merges their defect lists into one report. Best for regression suites — bounded by how many devices you actually have. |
+
+**Output layout:**
+```
+executions/execu_<YYYY-MM-DD_HH-MM-SS>/
+├── report.md
+├── extent-report.html                 # interactive dashboard (see extent-report skill)
+├── mobile-sessions/<session>/{logs,screenshots}/
+└── bugs/{bug-list.md,screenshots/}
+```
+
+**Setup:**
+```bash
+npm install -D appium
+npx appium driver install uiautomator2   # Android
+npx appium driver install xcuitest       # iOS (macOS + Xcode only)
+```
+Optionally, for the bundled wrapper script instead of raw `curl`:
+```bash
+npm install -D webdriverio
+```
+Copy the `permissions` block from [`settings.example.json`](../settings.example.json) into your
+project's `.claude/settings.json` to pre-approve `appium` and the read-only `adb`/`xcrun`
+commands, and to prompt (rather than block) before destructive device actions like uninstall
+or reboot.
+
+**Driving a session — two options:**
+- Raw WebDriver REST via `curl` against the running Appium server — no extra dependency.
+- The bundled `appium_client.js` wrapper (needs `webdriverio`) — simpler flag-driven commands.
+
+Pick whichever fits your project; both are documented in the skill's `references/` folder.
+
+**Reference:**
+- Skill: `skills/mobile-testing/SKILL.md`
+- Subagent: `agents/mobile-qa-executor.md`
+- Driver notes: `skills/mobile-testing/references/appium-server-cli.md` and
+  `references/appium-client-wrapper.md`
+- HTML dashboard: see [extent-report](./extent-report.md)

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,5 +1,5 @@
 {
-  "//": "RECOMMENDED PERMISSIONS for AgenTeX (Browser Testing + Azure DevOps task estimation). Plugin settings.json cannot carry permission rules, so copy the blocks below into your PROJECT .claude/settings.json (merge with any existing 'permissions'). These pre-approve the safe commands, gate destructive ones behind a prompt, and deny secret reads / destructive actions.",
+  "//": "RECOMMENDED PERMISSIONS for AgenTeX (Browser Testing + Mobile Testing + Azure DevOps task estimation). Plugin settings.json cannot carry permission rules, so copy the blocks below into your PROJECT .claude/settings.json (merge with any existing 'permissions'). These pre-approve the safe commands, gate destructive ones behind a prompt, and deny secret reads / destructive actions.",
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
@@ -22,14 +22,30 @@
       "Bash(az keyvault secret list:*)",
       "Bash(az aks list:*)",
       "Bash(curl:*)",
-      "Bash(sqlcmd:*)"
+      "Bash(sqlcmd:*)",
+      "Bash(npx appium:*)",
+      "Bash(adb devices:*)",
+      "Bash(adb version:*)",
+      "Bash(adb logcat:*)",
+      "Bash(adb shell dumpsys:*)",
+      "Bash(xcrun simctl list:*)",
+      "Bash(xcrun simctl boot:*)",
+      "Bash(xcrun simctl spawn:*)"
     ],
     "ask": [
       "Bash(az boards work-item delete:*)",
       "Bash(az webapp deploy:*)",
       "Bash(az storage blob upload:*)",
       "Bash(az aks get-credentials:*)",
-      "Bash(az group create:*)"
+      "Bash(az group create:*)",
+      "Bash(adb uninstall:*)",
+      "Bash(adb shell pm uninstall:*)",
+      "Bash(adb shell pm clear:*)",
+      "Bash(adb reboot:*)",
+      "Bash(adb root:*)",
+      "Bash(adb emu kill:*)",
+      "Bash(xcrun simctl erase:*)",
+      "Bash(xcrun simctl uninstall:*)"
     ],
     "deny": [
       "Read(./secrets/**)",

--- a/skills/mobile-testing/SKILL.md
+++ b/skills/mobile-testing/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: mobile-testing
+description: Test a native mobile app (Android/iOS) by driving it through Appium. Use whenever the user wants to test a mobile app for defects — happy paths, edge cases, and negative cases — either sequentially (human-in-the-loop, the default) or in parallel (autonomous, one session per available device/emulator). Produces per-scenario screenshots and logs plus a consolidated defect report. Read this before starting any mobile testing run.
+---
+
+# Mobile Testing Agent
+
+## Role
+You are a QA test engineer. You test native mobile apps (Android/iOS) by driving a real
+Appium session (run via Bash, either raw WebDriver REST calls or the bundled wrapper script —
+see Tools below). You do **not** modify application code. Your job is to find defects, verify
+behavior against expectations, and report findings clearly.
+
+## Target & environment resolution
+
+Resolve once, before any device action, in this order:
+
+1. **Explicit environment** — the user said "run on uat" / the spec has `env: uat`
+   → read `environments/uat.json`.
+2. **Default** — `defaultEnvironment` in `config/project.json` → that file.
+3. **Legacy project** (no such files) — there is no legacy mobile equivalent of
+   `QA_TARGET_URL`; ask the user for the app path/package and device capabilities instead of
+   guessing.
+
+From the environment file's `mobile` block (see `docs/configuration.md`): `platformName`
+(`Android`/`iOS`), `automationName` (`UiAutomator2`/`XCUITest`), `app` (path to a local
+`.apk`/`.ipa`) **or** `appPackage`+`appActivity` (Android, already installed) / `bundleId`
+(iOS, already installed), `deviceName`, `platformVersion`, optional `udid` (a specific real
+device). `defaults` and `users` from the same environment file are the test data for the run,
+same convention as browser-testing: a spec step like "login as expired_user" means
+`users.expired_user`; a user without `password` uses `defaults.password`; a
+`{ "envSecret": "NAME" }` value means read `NAME` from `.env` — never print it.
+
+Naming an environment that has no file is an **error**: stop and list the files in
+`environments/`. Never silently fall back to another environment, and never invent capability
+values that aren't in the file. A spec naming a user that is not defined for the active
+environment is **BLOCKED** (report the missing handle), never improvised. Record the active
+environment name and the resolved `platformName`/`deviceName` in `report.md`.
+
+## Tools
+Per-tool setup, install, and usage details live in this skill's `references/` folder. **Read
+the relevant file BEFORE the first use of that tool in a session**, and again whenever a
+command behaves unexpectedly. There are two ways to drive a session — pick whichever the
+project already uses (or the simpler one, raw REST, when neither is established):
+
+- **`${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/references/appium-server-cli.md`** — start the
+  Appium server, install platform drivers, and drive a session with raw `curl` calls against
+  the W3C WebDriver REST API (create session, find element, tap, type, screenshot, swipe,
+  back, close). No extra project dependency beyond `appium` itself.
+- **`${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/references/appium-client-wrapper.md`** — drive
+  a session through the bundled `scripts/appium_client.js` wrapper (simple flag-driven
+  subcommands, one JSON line per call). Requires the project to have `webdriverio` installed
+  (`npm install -D webdriverio`).
+
+Always-on rules (full details in the files above):
+- **Parallel runs MUST each target their own device/emulator** (own `udid`/AVD/simulator) —
+  sessions on the same physical device collide. Unlike headless browser sessions, mobile
+  concurrency is bounded by **available emulators/devices on the machine**, not just CPU/RAM —
+  expect far fewer concurrent sessions than browser-testing's ~6-8; often just 1-2 unless
+  multiple emulators/devices are actually provisioned.
+- App/device errors surfaced in the Appium server log or in `adb logcat` count as defects even
+  if the UI looks fine.
+- Specs may include **`api:` / `db:` steps** (verify via API, check a DB row, seed data) —
+  execute them via the **api-integration** / **db-integration** skills' runner scripts, from
+  the project's `integration/` catalog (read the relevant SKILL.md before the first such
+  step). Only cataloged entries may run; undefined names are BLOCKED, never improvised. Pass
+  the resolved environment name via `--env <name>` — sequential mode included, not just
+  parallel. Specs may also include **`kb:`** steps (advisory only, never PASS/FAIL) — execute
+  via the **ask-kb** skill's runner script.
+- Helper scripts (all in `${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/scripts/`, each prints
+  one JSON line): `preflight.js` — check all tools in one call at session start; `init_run.js
+  --sessions a,b` — create the whole execution tree (use instead of mkdir chains); `merge_run.js
+  --run-dir <dir> <evidence paths...>` — copy bug-evidence screenshots into
+  `bugs/screenshots/` during MERGE.
+
+## Execution output layout
+Every run writes ALL its data under one timestamped folder (created in the current project) —
+nothing scattered elsewhere.
+
+```
+executions/
+└── execu_<YYYY-MM-DD_HH-MM-SS>/        # one folder per execution
+    ├── report.md                       # final report          [orchestrator]
+    ├── mobile-sessions/
+    │   └── <session>/                   # one per device session [subagent owns its own]
+    │       ├── logs/                    #   Appium server / adb logcat captures
+    │       └── screenshots/             #   every scenario screenshot
+    └── bugs/
+        ├── bug-list.md                  # consolidated defects  [orchestrator]
+        └── screenshots/                 #   copies of bug-evidence shots
+```
+
+Ownership:
+- **Orchestrator (you, the main agent):** create `execu_<ts>/` + the `mobile-sessions/` and
+  `bugs/` skeleton, pick the timestamp, assign each subagent its `SESSION_DIR` and target
+  device, write `report.md`, and build `bugs/` (merge `bug-list.md` + copy the bug-evidence
+  screenshots each subagent flagged).
+- **Subagent (per session):** writes ONLY into its own
+  `mobile-sessions/<session>/{logs,screenshots}` and returns the screenshot paths that prove
+  each defect. Dispatch the bundled **`mobile-qa-executor`** agent for this.
+- Sequential mode uses a single session named `default` (`mobile-sessions/default/`).
+
+## Modes
+Pick the mode from how the user invokes the run. **Sequential is the default.** Switch to
+**Parallel** only when they explicitly ask for a parallel / fast / regression / autonomous run
+**and** confirm more than one device/emulator is actually available.
+
+### Sequential mode (default) — human-in-the-loop
+Follow this loop and STOP for approval at each checkpoint. Do not skip ahead.
+
+1. **UNDERSTAND** — Restate what we're testing (app, platform, device) and the acceptance
+   criteria in your own words.
+   → Checkpoint: wait for the user to confirm scope.
+2. **PLAN** — List the test scenarios (happy path, edge cases, negative cases) as a numbered
+   plan. Do NOT open a session yet.
+   → Checkpoint: wait for the user to approve the plan.
+3. **EXECUTE** — Run scenarios one at a time. After each scenario, report PASS/FAIL with
+   evidence (screenshot + observed vs. expected).
+   → Checkpoint: pause after each scenario before moving to the next.
+4. **REPORT** — Create `executions/execu_<timestamp>/` (single session `default`), save
+   screenshots/logs under `mobile-sessions/default/`, then write `report.md` + `bugs/` there.
+   Summarize results as a defect list (format below). Optionally generate an interactive
+   `extent-report.html` next to `report.md` via the **extent-report** skill.
+
+### Parallel mode — autonomous
+Run end to end WITHOUT stopping for per-checkpoint approval; present the final report when
+done.
+
+1. **SETUP** — Create `executions/execu_<timestamp>/` with `mobile-sessions/` and `bugs/`
+   subfolders (see Execution output layout above).
+2. **LOAD** — Read the planned test files (one bucket per file). By convention these live in
+   `test/mobile-suite1/` (or wherever the user keeps their mobile specs). Stateful scenarios
+   stay grouped and run sequentially within their own file.
+   - **First run:** if no `test/mobile-suite1/` specs exist yet, copy the bundled samples from
+     `${CLAUDE_PLUGIN_ROOT}/test/mobile-suite1/` into `./test/mobile-suite1/` as an editable
+     starting point, and tell the user to adapt them to their app before a real regression.
+3. **DISPATCH** — Spawn one **`mobile-qa-executor`** subagent per test file, each targeting its
+   own device/emulator, injecting its `SESSION`, `SESSION_DIR`
+   (`…/mobile-sessions/<session>`), `WORKING_DIR`, `ENVIRONMENT`, `MOBILE_CAPS` (the resolved
+   `mobile` block), `TEST_DATA`, and `TEST_SPEC`. `TEST_DATA` is the environment's `defaults` +
+   `users` JSON (secrets left as `{ envSecret }` refs — the executor resolves them only at use
+   time and never prints them). Launch them in a single batch. Confirm device availability
+   first — do not dispatch more subagents than there are devices/emulators to run them on.
+4. **MERGE** — Collect each subagent's report; write the final `report.md` and build `bugs/`
+   (`bug-list.md` + copy the bug-evidence screenshots each subagent flagged) inside the
+   execution folder. Use the defect format below. Optionally generate an interactive
+   `extent-report.html` next to `report.md` via the **extent-report** skill.
+5. **PRESENT** — Show the merged summary.
+
+Autonomy boundary (applies in parallel mode): still never modify app source, never create real
+accounts or complete a real purchase, never print secrets, never use real personal data (use
+disposable values like `qa.tester@example.com`), and never run a destructive device command
+(`adb uninstall`, `adb shell pm clear`, `adb reboot`, `adb root`, `xcrun simctl erase`, or
+similar) — a test run only installs/launches/exercises the app under test and tears down its
+own session. If the overall scope is ambiguous, ask once before dispatching; otherwise proceed
+without pausing.
+
+## Defect reporting format
+- **Title** — concise, action-oriented
+- **Steps to reproduce** — numbered, deterministic
+- **Expected** vs **Actual**
+- **Severity** — Critical / High / Medium / Low
+- **Evidence** — screenshot filename, Appium server / adb log notes
+
+## Rules
+- Think out loud: state your reasoning before each action so the user can follow the chain.
+- In **sequential mode**, never proceed past a checkpoint without an explicit "go" / "approved".
+  In **parallel mode**, do not pause for checkpoints — run autonomously within the autonomy
+  boundary above.
+- `config/project.json`, `environments/<env>.json`, and `.env` may be read to resolve config;
+  never print, log, or pass secret values (tokens, credentials, envSecret targets) anywhere.
+- Never modify application source code. You may write test notes/artifacts only.
+- Never run a destructive device command (uninstall, wipe/clear data, reboot, root/jailbreak
+  actions) against the target device/emulator — the run's footprint is limited to installing,
+  launching, exercising, and closing the session for the app under test.
+- If a step is ambiguous — including which device/emulator to target — ask, don't guess.

--- a/skills/mobile-testing/references/appium-client-wrapper.md
+++ b/skills/mobile-testing/references/appium-client-wrapper.md
@@ -1,0 +1,71 @@
+# Tool: appium_client.js — mechanics
+
+An optional alternative to driving the Appium server with raw `curl` (see
+`appium-server-cli.md`): a small bundled wrapper around
+[`webdriverio`](https://webdriver.io/)'s WebDriver client, exposing simple flag-driven
+subcommands. Prints **one JSON line** per call — `{"result":"PASS|FAIL|BLOCKED", ...}` — and
+exits 0/1/2. Use whichever driver mechanism the project already has set up; prefer this one
+once `webdriverio` is already a project dependency, since it saves hand-writing REST calls for
+find/tap/type/screenshot.
+
+## Requirement
+The project (not the plugin) needs `webdriverio` installed:
+```bash
+npm install -D webdriverio
+```
+The script resolves `webdriverio` from the **current working directory** at run time (the
+plugin itself ships no npm dependencies). If it isn't installed, every subcommand prints
+`{"result":"BLOCKED","reason":"webdriverio not found — run: npm install -D webdriverio"}`
+and exits 2 — install it and retry, never work around it another way.
+
+An Appium server must already be running (`npx appium server`, default
+`http://127.0.0.1:4723`) — this script is a client, not a server launcher.
+
+## Usage
+```
+node ${CLAUDE_PLUGIN_ROOT}/skills/mobile-testing/scripts/appium_client.js <subcommand> [flags]
+```
+
+| Subcommand | Flags | Result payload (on PASS) |
+|---|---|---|
+| `create-session` | `--caps-file <path.json>` `[--server <url>]` | `{"sessionId":"..."}` |
+| `find` | `--session <id>` `--using <strategy>` `--value <selector>` `[--server <url>]` | `{"element":"<elementId>"}` |
+| `click` | `--session <id>` `--element <elementId>` | `{}` |
+| `send-keys` | `--session <id>` `--element <elementId>` `--text <text>` | `{}` |
+| `get-text` | `--session <id>` `--element <elementId>` | `{"text":"..."}` |
+| `screenshot` | `--session <id>` `--out <path.png>` | `{"path":"<path.png>"}` |
+| `swipe` | `--session <id>` `--from <x>,<y>` `--to <x>,<y>` | `{}` |
+| `back` | `--session <id>` | `{}` |
+| `source` | `--session <id>` | `{"source":"<xml>"}` |
+| `close-session` | `--session <id>` | `{}` |
+
+- `--using` strategies: `accessibility id` (preferred), `id`, `-android uiautomator`,
+  `-ios predicate string`, `-ios class chain`, `xpath`.
+- `--server` defaults to `http://127.0.0.1:4723`; only needed if the server runs elsewhere.
+- `create-session`'s `--caps-file` takes a W3C capabilities JSON file — see
+  `templates/sample-android-caps.json` / `templates/sample-ios-caps.json` in this skill, or
+  build one from the `mobile` block in `environments/<env>.json` per
+  `appium-server-cli.md`'s capability table.
+
+## Result shapes
+- `PASS` (exit 0) — `{"result":"PASS", ...subcommand-specific fields above}`.
+- `FAIL` (exit 1) — the Appium/WebDriver call itself failed (element not found, session
+  invalid, request error): `{"result":"FAIL","reason":"..."}`.
+- `BLOCKED` (exit 2) — a required flag is missing, `webdriverio` isn't resolvable, or the
+  caps file doesn't exist/parse: `{"result":"BLOCKED","reason":"..."}`.
+
+## Session handling
+Same as the raw REST approach: `create-session` returns a `sessionId` — capture it and pass it
+via `--session` to every subsequent call for that device session. Always call `close-session`
+at the end of a scenario run, even on failure, so the device/emulator is released.
+
+## Example flow
+```bash
+node appium_client.js create-session --caps-file caps.json
+# -> {"result":"PASS","sessionId":"abc123"}
+node appium_client.js find --session abc123 --using "accessibility id" --value login-button
+# -> {"result":"PASS","element":"elem-1"}
+node appium_client.js click --session abc123 --element elem-1
+node appium_client.js screenshot --session abc123 --out s1-login.png
+node appium_client.js close-session --session abc123
+```

--- a/skills/mobile-testing/references/appium-server-cli.md
+++ b/skills/mobile-testing/references/appium-server-cli.md
@@ -1,0 +1,114 @@
+# Tool: Appium server + raw WebDriver REST (via curl)
+
+Driving a mobile session directly against a running Appium server, using `curl` — no extra
+project dependency beyond `appium` itself. Read this before the first Appium action in a
+session, or when a call behaves unexpectedly. See
+[appium.io/docs](https://appium.io/docs/en/latest/) for the full upstream reference.
+
+## Setup & preflight
+- Install: `npm install -D appium` (local devDependency, invoked via `npx`).
+- Install the platform driver(s) you need:
+  - Android: `npx appium driver install uiautomator2`
+  - iOS (macOS + Xcode only): `npx appium driver install xcuitest`
+- Preflight: `npx appium --version`, `npx appium driver list --installed`.
+- Android also needs `adb` on PATH (from the Android SDK platform-tools) and either a running
+  emulator (`emulator -avd <name>`) or a connected device with USB debugging enabled — check
+  with `adb devices`.
+- iOS also needs a booted Simulator (`xcrun simctl list devices booted`) or a provisioned real
+  device; iOS automation only runs on macOS.
+- Start the server: `npx appium server` (defaults to `http://127.0.0.1:4723`). Appium 2.x
+  serves the WebDriver protocol at the base path `/` (no `/wd/hub` prefix, unlike Appium 1.x).
+  Run it in the background before driving any session; check it's up with
+  `curl -s http://127.0.0.1:4723/status`.
+
+## Capabilities
+Every session is created with a JSON payload of **capabilities**. Per W3C, vendor-specific
+capabilities are prefixed `appium:`. These map directly to the `mobile` block in
+`environments/<env>.json` (see `docs/configuration.md`):
+
+| `environments/<env>.json` field | W3C capability |
+|---|---|
+| `platformName` | `platformName` |
+| `automationName` | `appium:automationName` |
+| `app` | `appium:app` (path to `.apk`/`.ipa`, or an `http(s)://` URL) |
+| `appPackage` / `appActivity` | `appium:appPackage` / `appium:appActivity` (Android, already installed) |
+| `bundleId` | `appium:bundleId` (iOS, already installed) |
+| `deviceName` | `appium:deviceName` |
+| `platformVersion` | `appium:platformVersion` |
+| `udid` | `appium:udid` (target one specific real device/simulator) |
+
+Android example (`caps.json`):
+```json
+{ "capabilities": { "alwaysMatch": {
+  "platformName": "Android",
+  "appium:automationName": "UiAutomator2",
+  "appium:app": "/absolute/path/to/app.apk",
+  "appium:deviceName": "emulator-5554"
+} } }
+```
+
+iOS example:
+```json
+{ "capabilities": { "alwaysMatch": {
+  "platformName": "iOS",
+  "appium:automationName": "XCUITest",
+  "appium:app": "/absolute/path/to/app.app",
+  "appium:deviceName": "iPhone 15",
+  "appium:platformVersion": "17.5"
+} } }
+```
+
+## Session handling
+Unlike `playwright-cli`'s named `-s=<session>` sessions, the Appium server has no server-side
+session names — `POST /session` returns a `sessionId` in the response body, and **you must
+capture and pass it in every subsequent call's URL** for that device session. Keep it in a
+shell variable for the duration of the scenario run:
+```bash
+SID=$(curl -s -X POST http://127.0.0.1:4723/session -H 'Content-Type: application/json' -d @caps.json | node -pe 'JSON.parse(require("fs").readFileSync(0,"utf8")).value.sessionId')
+```
+
+## Core commands (W3C WebDriver REST)
+All examples assume `$BASE=http://127.0.0.1:4723` and `$SID` holds the active session id.
+
+- **Create session** — `POST $BASE/session` with the capabilities payload above. Response:
+  `{"value":{"sessionId":"...", "capabilities": {...}}}`.
+- **Find element** — `POST $BASE/session/$SID/element`
+  `{"using":"accessibility id","value":"login-button"}`. Common `using` strategies: `accessibility id`
+  (preferred — stable, cross-platform), `id` (Android resource-id), `-android uiautomator`
+  (Android UiSelector expression), `-ios predicate string` / `-ios class chain` (iOS), `xpath`
+  (slow, last resort). Response: `{"value":{"ELEMENT":"<id>"}}` (or `{"value":{"element-...":"<id>"}}`
+  depending on server version — read whichever key is present).
+- **Click / tap** — `POST $BASE/session/$SID/element/<elementId>/click`.
+- **Type text** — `POST $BASE/session/$SID/element/<elementId>/value` `{"text":"hello"}`.
+- **Get text** — `GET $BASE/session/$SID/element/<elementId>/text`.
+- **Screenshot** — `GET $BASE/session/$SID/screenshot` → `{"value":"<base64 PNG>"}`. Decode and
+  save, e.g.: `curl -s $BASE/session/$SID/screenshot | node -e 'const d=JSON.parse(require("fs").readFileSync(0,"utf8"));require("fs").writeFileSync(process.argv[1],Buffer.from(d.value,"base64"))' <out.png>`.
+- **Page source** (accessibility tree, for locating elements) — `GET $BASE/session/$SID/source`.
+- **Back** — `POST $BASE/session/$SID/back`.
+- **Swipe** — no dedicated endpoint; use the W3C Actions API,
+  `POST $BASE/session/$SID/actions` with a single pointer input performing move→down→move→up,
+  e.g. a vertical swipe from (500,1500) to (500,500):
+  ```json
+  {"actions":[{"type":"pointer","id":"finger1","parameters":{"pointerType":"touch"},
+    "actions":[
+      {"type":"pointerMove","duration":0,"x":500,"y":1500},
+      {"type":"pointerDown","button":0},
+      {"type":"pointerMove","duration":300,"x":500,"y":500},
+      {"type":"pointerUp","button":0}
+    ]}]}
+  ```
+- **Close session** — `DELETE $BASE/session/$SID`. Always run this at the end of a scenario
+  run, even on failure, so the device/emulator is free for the next session.
+
+## Logs & defects
+- Android: `adb logcat -d` (or filtered by package) for app crashes/errors; treat unexpected
+  stack traces or ANRs as defects even if the screen looks fine.
+- iOS: `xcrun simctl spawn booted log stream --level info` for simulator logs.
+- The Appium server's own stdout/stderr is also useful evidence — redirect it to a log file
+  under the run's `mobile-sessions/<session>/logs/` when starting the server for a session.
+
+## Concurrency
+Each session needs its own real emulator/device/simulator — there is no equivalent of
+headless-browser cheapness. Confirm how many are actually provisioned
+(`adb devices` / `xcrun simctl list devices booted`) before planning a parallel run; one
+session per device, never two sessions sharing one device.

--- a/skills/mobile-testing/scripts/appium_client.js
+++ b/skills/mobile-testing/scripts/appium_client.js
@@ -1,0 +1,133 @@
+// AgenTeX mobile driver — thin wrapper around webdriverio for driving an Appium session
+// with simple flag-driven subcommands. Prints ONE JSON line: {"result":"PASS|FAIL|BLOCKED", ...}.
+// Exit: 0 PASS, 1 FAIL, 2 BLOCKED.
+//
+// Usage:
+//   node appium_client.js create-session --caps-file <path.json> [--server <url>]
+//   node appium_client.js find --session <id> --using <strategy> --value <selector> [--server <url>]
+//   node appium_client.js click --session <id> --element <elementId> [--server <url>]
+//   node appium_client.js send-keys --session <id> --element <elementId> --text <text> [--server <url>]
+//   node appium_client.js get-text --session <id> --element <elementId> [--server <url>]
+//   node appium_client.js screenshot --session <id> --out <path.png> [--server <url>]
+//   node appium_client.js swipe --session <id> --from <x>,<y> --to <x>,<y> [--server <url>]
+//   node appium_client.js back --session <id> [--server <url>]
+//   node appium_client.js source --session <id> [--server <url>]
+//   node appium_client.js close-session --session <id> [--server <url>]
+//
+// The plugin ships NO npm dependencies of its own — `webdriverio` must be a devDependency of
+// the CALLING project. It is resolved dynamically against the current working directory (not
+// this script's own location), since this file lives inside the plugin install, not the
+// consumer's project. See references/appium-client-wrapper.md.
+const fs = require('fs');
+
+function out(obj, code) { console.log(JSON.stringify(obj)); process.exitCode = code; }
+function blocked(reason, extra) { console.log(JSON.stringify({ result: 'BLOCKED', reason, ...extra })); process.exit(2); }
+function fail(reason) { out({ result: 'FAIL', reason }, 1); }
+
+// ---- resolve webdriverio from the caller's project, not the plugin's own install ----
+function loadWebdriverio() {
+  try {
+    const resolved = require.resolve('webdriverio', { paths: [process.cwd()] });
+    return require(resolved);
+  } catch (e) {
+    return null;
+  }
+}
+
+// ---- args ----
+const [, , subcommand, ...rest] = process.argv;
+const flags = {};
+for (let i = 0; i < rest.length; i++) {
+  if (rest[i].startsWith('--')) { flags[rest[i].slice(2)] = rest[i + 1]; i++; }
+}
+const KNOWN = ['create-session', 'find', 'click', 'send-keys', 'get-text', 'screenshot', 'swipe', 'back', 'source', 'close-session'];
+if (!subcommand || !KNOWN.includes(subcommand)) blocked(`usage: appium_client.js <${KNOWN.join('|')}> [flags]`);
+
+const wdio = loadWebdriverio();
+if (!wdio) blocked('webdriverio not found — run: npm install -D webdriverio');
+const { remote, attach } = wdio;
+
+function parseServer(server) {
+  const url = new URL(server || 'http://127.0.0.1:4723');
+  return {
+    protocol: url.protocol.replace(':', ''),
+    hostname: url.hostname,
+    port: url.port ? parseInt(url.port, 10) : (url.protocol === 'https:' ? 443 : 80),
+    path: url.pathname === '/' ? '/' : url.pathname,
+  };
+}
+
+async function attachSession(sessionId, server) {
+  return attach({ sessionId, capabilities: {}, requestedCapabilities: {}, ...parseServer(server) });
+}
+
+(async () => {
+  try {
+    if (subcommand === 'create-session') {
+      if (!flags['caps-file']) blocked('usage: create-session --caps-file <path.json> [--server <url>]');
+      if (!fs.existsSync(flags['caps-file'])) blocked(`caps file not found: ${flags['caps-file']}`);
+      let capsDoc;
+      try { capsDoc = JSON.parse(fs.readFileSync(flags['caps-file'], 'utf8')); }
+      catch (e) { blocked(`invalid JSON in ${flags['caps-file']}: ${e.message}`); }
+      const capabilities = (capsDoc.capabilities && capsDoc.capabilities.alwaysMatch) || capsDoc.capabilities || capsDoc;
+      const browser = await remote({ capabilities, logLevel: 'silent', ...parseServer(flags.server) });
+      out({ result: 'PASS', sessionId: browser.sessionId }, 0);
+      process.exit(0); // don't wait on any lingering handles; the Appium session itself persists server-side
+      return;
+    }
+
+    if (!flags.session) blocked(`usage: ${subcommand} --session <id> ... [--server <url>]`);
+    const browser = await attachSession(flags.session, flags.server);
+
+    if (subcommand === 'find') {
+      if (!flags.using || !flags.value) blocked('usage: find --session <id> --using <strategy> --value <selector>');
+      const el = await browser.findElement(flags.using, flags.value);
+      const elementId = el.ELEMENT || el['element-6066-11e4-a52e-4f735466cecf'];
+      if (!elementId) fail(`element not found: ${flags.using}=${flags.value}`);
+      else out({ result: 'PASS', element: elementId }, 0);
+    } else if (subcommand === 'click') {
+      if (!flags.element) blocked('usage: click --session <id> --element <elementId>');
+      await browser.elementClick(flags.element);
+      out({ result: 'PASS' }, 0);
+    } else if (subcommand === 'send-keys') {
+      if (!flags.element || flags.text === undefined) blocked('usage: send-keys --session <id> --element <elementId> --text <text>');
+      await browser.elementSendKeys(flags.element, flags.text);
+      out({ result: 'PASS' }, 0);
+    } else if (subcommand === 'get-text') {
+      if (!flags.element) blocked('usage: get-text --session <id> --element <elementId>');
+      const text = await browser.getElementText(flags.element);
+      out({ result: 'PASS', text }, 0);
+    } else if (subcommand === 'screenshot') {
+      if (!flags.out) blocked('usage: screenshot --session <id> --out <path.png>');
+      const b64 = await browser.takeScreenshot();
+      fs.mkdirSync(require('path').dirname(flags.out), { recursive: true });
+      fs.writeFileSync(flags.out, Buffer.from(b64, 'base64'));
+      out({ result: 'PASS', path: flags.out }, 0);
+    } else if (subcommand === 'swipe') {
+      if (!flags.from || !flags.to) blocked('usage: swipe --session <id> --from <x>,<y> --to <x>,<y>');
+      const [fx, fy] = flags.from.split(',').map(Number);
+      const [tx, ty] = flags.to.split(',').map(Number);
+      await browser.performActions([{
+        type: 'pointer', id: 'finger1', parameters: { pointerType: 'touch' },
+        actions: [
+          { type: 'pointerMove', duration: 0, x: fx, y: fy },
+          { type: 'pointerDown', button: 0 },
+          { type: 'pointerMove', duration: 300, x: tx, y: ty },
+          { type: 'pointerUp', button: 0 },
+        ],
+      }]);
+      out({ result: 'PASS' }, 0);
+    } else if (subcommand === 'back') {
+      await browser.back();
+      out({ result: 'PASS' }, 0);
+    } else if (subcommand === 'source') {
+      const source = await browser.getPageSource();
+      out({ result: 'PASS', source }, 0);
+    } else if (subcommand === 'close-session') {
+      await browser.deleteSession();
+      out({ result: 'PASS' }, 0);
+    }
+  } catch (e) {
+    fail(e.message);
+  }
+})();

--- a/skills/mobile-testing/scripts/appium_client.test.js
+++ b/skills/mobile-testing/scripts/appium_client.test.js
@@ -1,0 +1,82 @@
+'use strict';
+// Self-contained test: covers argument-parsing / BLOCKED paths without needing a live Appium
+// server, a device, or webdriverio installed. Run: node appium_client.test.js
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const RUNNER = path.join(__dirname, 'appium_client.js');
+let passed = 0;
+
+function run(args, cwd) {
+  const r = spawnSync('node', [RUNNER, ...args], { encoding: 'utf8', cwd: cwd || __dirname });
+  return { code: r.status, json: JSON.parse(r.stdout.trim()) };
+}
+
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log('  ok -', name);
+}
+
+// A cwd with no node_modules/webdriverio at all, so resolution always fails deterministically
+// regardless of whether webdriverio happens to be installed somewhere above this repo.
+const bareCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'agentex-mobile-test-'));
+
+test('no subcommand -> BLOCKED, exit 2', () => {
+  const r = run([], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+});
+
+test('unknown subcommand -> BLOCKED, exit 2', () => {
+  const r = run(['not-a-command'], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+});
+
+test('webdriverio not installed -> BLOCKED, exit 2, with install hint', () => {
+  const r = run(['create-session', '--caps-file', 'caps.json'], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+  assert.match(r.json.reason, /webdriverio/);
+});
+
+// Fake a resolvable "webdriverio" so we can reach the flag-validation branches below it.
+const fakeModulesDir = path.join(bareCwd, 'node_modules', 'webdriverio');
+fs.mkdirSync(fakeModulesDir, { recursive: true });
+fs.writeFileSync(path.join(fakeModulesDir, 'package.json'), JSON.stringify({ name: 'webdriverio', main: 'index.js' }));
+fs.writeFileSync(path.join(fakeModulesDir, 'index.js'), 'module.exports = { remote: async () => { throw new Error("no server"); }, attach: async () => { throw new Error("no server"); } };');
+
+test('create-session missing --caps-file -> BLOCKED, exit 2', () => {
+  const r = run(['create-session'], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+});
+
+test('create-session with missing caps file path -> BLOCKED, exit 2', () => {
+  const r = run(['create-session', '--caps-file', 'does-not-exist.json'], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+  assert.match(r.json.reason, /not found/);
+});
+
+test('create-session with invalid JSON caps file -> BLOCKED, exit 2', () => {
+  const badCaps = path.join(bareCwd, 'bad-caps.json');
+  fs.writeFileSync(badCaps, '{ not valid json');
+  const r = run(['create-session', '--caps-file', badCaps], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+  assert.match(r.json.reason, /invalid JSON/);
+});
+
+test('find missing --session -> BLOCKED, exit 2', () => {
+  const r = run(['find', '--using', 'accessibility id', '--value', 'x'], bareCwd);
+  assert.strictEqual(r.code, 2);
+  assert.strictEqual(r.json.result, 'BLOCKED');
+});
+
+console.log(`\n${passed} passed`);
+fs.rmSync(bareCwd, { recursive: true, force: true });

--- a/skills/mobile-testing/scripts/init_run.js
+++ b/skills/mobile-testing/scripts/init_run.js
@@ -1,0 +1,30 @@
+// AgenTeX mobile run scaffolder — creates the execution output tree for one run in a single call.
+//
+// Usage: node init_run.js [--sessions name1,name2,...]   (default: one session "default")
+// Prints ONE JSON line: {"runDir": "...", "bugsDir": "...", "sessions": {name: {dir, logs, screenshots}}}
+const fs = require('fs');
+const path = require('path');
+
+let sessions = ['default'];
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--sessions') sessions = args[++i].split(',').map(s => s.trim()).filter(Boolean);
+}
+
+const d = new Date();
+const p = n => String(n).padStart(2, '0');
+const ts = `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}_${p(d.getHours())}-${p(d.getMinutes())}-${p(d.getSeconds())}`;
+const runDir = path.join('executions', `execu_${ts}`);
+const bugsDir = path.join(runDir, 'bugs');
+fs.mkdirSync(path.join(bugsDir, 'screenshots'), { recursive: true });
+
+const out = { runDir, bugsDir, sessions: {} };
+for (const s of sessions) {
+  const dir = path.join(runDir, 'mobile-sessions', s);
+  const logs = path.join(dir, 'logs');
+  const screenshots = path.join(dir, 'screenshots');
+  fs.mkdirSync(logs, { recursive: true });
+  fs.mkdirSync(screenshots, { recursive: true });
+  out.sessions[s] = { dir, logs, screenshots };
+}
+console.log(JSON.stringify(out));

--- a/skills/mobile-testing/scripts/merge_run.js
+++ b/skills/mobile-testing/scripts/merge_run.js
@@ -1,0 +1,30 @@
+// AgenTeX mobile evidence merger — copies the bug-evidence screenshots each subagent flagged
+// into the run's bugs/screenshots/ folder, in one call.
+//
+// Usage: node merge_run.js --run-dir executions/execu_<ts> <evidence-path> [<evidence-path> ...]
+// Prints ONE JSON line: {"copied": [...], "missing": [...]}
+// (Writing bugs/bug-list.md and report.md stays with the orchestrator — that's judgment.)
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+let runDir; const evidence = [];
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--run-dir') runDir = args[++i];
+  else evidence.push(args[i]);
+}
+if (!runDir) { console.log(JSON.stringify({ error: 'usage: --run-dir <dir> <evidence-path>...' })); process.exit(2); }
+
+const dest = path.join(runDir, 'bugs', 'screenshots');
+fs.mkdirSync(dest, { recursive: true });
+
+const copied = [], missing = [];
+for (const src of evidence) {
+  if (!fs.existsSync(src)) { missing.push(src); continue; }
+  // prefix with the session name (…/mobile-sessions/<session>/screenshots/x.png) to avoid collisions
+  const m = src.replace(/\\/g, '/').match(/mobile-sessions\/([^/]+)\//);
+  const name = (m ? `${m[1]}-` : '') + path.basename(src);
+  fs.copyFileSync(src, path.join(dest, name));
+  copied.push(path.join(dest, name));
+}
+console.log(JSON.stringify({ copied, missing }));

--- a/skills/mobile-testing/scripts/preflight.js
+++ b/skills/mobile-testing/scripts/preflight.js
@@ -1,0 +1,25 @@
+// AgenTeX mobile preflight — checks every tool a mobile run might need, in one call.
+//
+// Usage: node preflight.js
+// Prints ONE JSON line: {"node":{...}, "appium":{...}, "adb":{...}, "xcrun":{...}, "curl":{...}}
+// — informational, always exits 0. The agent decides what's required for the run at hand
+// (xcrun only matters for iOS, adb only for Android, etc.)
+const { spawnSync } = require('child_process');
+
+function probe(cmd, args) {
+  try {
+    // single command string: avoids DEP0190 (shell:true with an args array) on Windows
+    const r = spawnSync([cmd, ...args].join(' '), { encoding: 'utf8', timeout: 60000, shell: true });
+    if (r.error || r.status !== 0) return { ok: false, error: (r.error && r.error.message) || (r.stderr || '').trim().split('\n')[0] || `exit ${r.status}` };
+    const first = ((r.stdout || '') + (r.stderr || '')).trim().split('\n').find(l => l.trim()) || '';
+    return { ok: true, version: first.trim().slice(0, 120) };
+  } catch (e) { return { ok: false, error: e.message }; }
+}
+
+console.log(JSON.stringify({
+  node: { ok: true, version: process.version },
+  appium: probe('npx', ['appium', '--version']),
+  adb: probe('adb', ['version']),
+  xcrun: probe('xcrun', ['simctl', 'help']),
+  curl: probe('curl', ['--version']),
+}));

--- a/skills/mobile-testing/templates/sample-android-caps.json
+++ b/skills/mobile-testing/templates/sample-android-caps.json
@@ -1,0 +1,10 @@
+{
+  "capabilities": {
+    "alwaysMatch": {
+      "platformName": "Android",
+      "appium:automationName": "UiAutomator2",
+      "appium:app": "/absolute/path/to/app.apk",
+      "appium:deviceName": "emulator-5554"
+    }
+  }
+}

--- a/skills/mobile-testing/templates/sample-ios-caps.json
+++ b/skills/mobile-testing/templates/sample-ios-caps.json
@@ -1,0 +1,11 @@
+{
+  "capabilities": {
+    "alwaysMatch": {
+      "platformName": "iOS",
+      "appium:automationName": "XCUITest",
+      "appium:app": "/absolute/path/to/app.app",
+      "appium:deviceName": "iPhone 15",
+      "appium:platformVersion": "17.5"
+    }
+  }
+}

--- a/templates/environments/qa.json
+++ b/templates/environments/qa.json
@@ -18,5 +18,11 @@
   "api": {
     "baseUrl": "https://jsonplaceholder.typicode.com",
     "token": { "envSecret": "API_TOKEN" }
+  },
+  "mobile": {
+    "platformName": "Android",
+    "automationName": "UiAutomator2",
+    "app": "/absolute/path/to/app.apk",
+    "deviceName": "emulator-5554"
   }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -54,6 +54,13 @@ db:  sample-db.todo-by-title(title=qa-test-item) → expect 1 row
 - Parallel (autonomous, one session per file): ask for a "parallel regression from the
   specs in `test/suite1/`".
 
+## Mobile app specs
+
+Native Android/iOS specs work the same way, one folder over: `test/mobile-suite1/` (seeded by
+`/execute-mobile-test` on first run — same lazy-scaffold behavior as `suite1/` above). See
+[Mobile Testing](../docs/mobile-testing.md) for how a mobile spec differs (app under test and
+element selectors instead of a URL and CSS selectors).
+
 ## Azure DevOps (optional)
 
 AgenTeX can also work your ADO backlog — fill the `azure` block in `config/project.json` first

--- a/test/mobile-suite1/apidemos-navigation.md
+++ b/test/mobile-suite1/apidemos-navigation.md
@@ -1,0 +1,22 @@
+# Spec: API Demos category navigation
+
+App under test: `io.appium.android.apis` (ApiDemos-debug.apk — the official Appium sample app,
+downloadable from the Appium project; a good target for a first smoke run)
+Type: navigation — read-only, stateful chain
+
+## Acceptance criteria
+- The home screen lists the API Demos categories (Accessibility, Animation, App, Content,
+  Graphics, Media, NFC, OS, Preference, Text, Views).
+- Tapping a category opens its list screen.
+- Using back from a category screen returns to the home category list without crashing.
+
+## Scenarios (stateful — run in order, in one session)
+1. Launch the app; expect the home screen listing all categories, including "Views".
+2. Tap "Views"; expect a new screen (not the home category list) to open.
+3. Use back; expect the home category list to return, "Graphics" visible again.
+4. Tap "Graphics"; expect a new screen (not the home category list) to open.
+5. Use back; expect the home category list to return.
+
+## Notes
+- Screenshot every scenario (pass and fail).
+- Treat any crash/ANR in the device log as a defect even if the UI looks fine.

--- a/test/mobile-suite1/login.md
+++ b/test/mobile-suite1/login.md
@@ -1,0 +1,26 @@
+# Spec: App login
+
+App under test: (fill in — `.apk`/`.ipa` path or installed `appPackage`/`bundleId`, via the
+`mobile` block in `environments/<env>.json`)
+Type: login / validation — no real account is created (validation-only)
+
+## Acceptance criteria
+- A valid disposable test user reaches a visible logged-in / home state.
+- An invalid password is rejected with a specific, visible error; the app must not proceed
+  past the login screen.
+- Leaving required fields empty shows an inline "required" error on each field.
+
+## Scenarios
+1. **Happy path** — log in as `valid_user` (from `environments/<env>.json`'s `users`); expect
+   the home screen's landmark element to become visible.
+2. **Wrong password** — log in as `valid_user` with an obviously wrong password; expect a
+   visible "invalid credentials" error, still on the login screen.
+3. **Empty fields** — tap login with both fields empty; expect an inline "required" error on
+   each field.
+
+## Notes
+- Screenshot every scenario (pass and fail).
+- Treat any app crash, ANR, or unexpected stack trace in the device log as a defect even if
+  the screen looks fine.
+- Never use a real personal account — `valid_user` should be a disposable/shared QA test
+  account defined in `environments/<env>.json`.

--- a/test/mobile-suite1/navigation.md
+++ b/test/mobile-suite1/navigation.md
@@ -1,0 +1,22 @@
+# Spec: Primary navigation
+
+App under test: (fill in — `.apk`/`.ipa` path or installed `appPackage`/`bundleId`, via the
+`mobile` block in `environments/<env>.json`)
+Type: navigation — read-only, stateful chain
+
+## Acceptance criteria
+- Each primary tab/menu item opens its expected screen (checked by a landmark element).
+- Using the device back gesture/button from a secondary screen returns to the previous one
+  without crashing or losing app state.
+
+## Scenarios (stateful — run in order, in one session)
+1. Launch the app; expect the home screen's landmark element to be visible.
+2. Open each primary tab/menu item in turn; expect that screen's landmark element to become
+   visible after each tap.
+3. From the last tab opened, use back; expect a return to the previous screen (not a crash or
+   blank screen).
+
+## Notes
+- Stateful: keep these steps in the same session, in the order above.
+- Screenshot each step; flag any app crash, ANR, or unexpected error in the device log as a
+  defect.


### PR DESCRIPTION
Adds a new mobile-testing capability alongside the existing browser-testing flow: a skill (SKILL.md + two driver references, raw WebDriver REST via curl and a webdriverio-based wrapper script), a dedicated mobile-qa-executor subagent, the /execute-mobile-test command, bundled starter specs, and a user-facing docs page. Config gains an optional `mobile` block in environments/<env>.json (additive, browser-only projects unaffected).

Also adds docs/contributing/adding-a-capability.md, a new contributing guide for additions bigger than one skill, using this addition as the worked example, and tightens settings.example.json so destructive adb/xcrun actions prompt instead of being blanket-approved.