### PR TITLE
feat: wire session login reuse (login.mode: session) into the test-run path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,17 @@ All notable changes to AgenTeX are documented here.
   cookies but **not** localStorage across a navigation (Playwright seeds localStorage only at
   context creation; the CLI's post-hoc load is wiped by the next `goto`), so it silently fails
   for localStorage-based auth. `session` mode therefore uses `open --persistent --profile`
-  (carries cookies + localStorage, drivable by the same CLI). Concurrency trade-off: a profile
-  dir can't be opened twice at once, so parallel specs sharing a user get a per-executor copy.
-  `state-save`'s `storageState` JSON is still the right artifact for a compiled `.spec.ts`
-  `storageState:` (that path seeds localStorage at newContext). A future open-time
-  `--storage-state` flag on the CLI would give portable-JSON reuse without profiles.
+  (carries cookies + localStorage, drivable by the same CLI). Concurrency limit: a profile dir
+  can't be opened twice at once, so parallel specs sharing a user get a per-executor copy — but
+  the copies **share one refresh token**, so concurrent same-user copies race on refresh-token
+  rotation (one is bounced with `REFRESH_TOKEN_INVALID`); schedule same-user specs sequentially
+  unless the app does not rotate on refresh (distinct users run concurrently). `state-save`'s
+  `storageState` JSON is still the right artifact for a compiled `.spec.ts` `storageState:`
+  (that path seeds localStorage at newContext). A future open-time `--storage-state` flag on
+  the CLI would give portable-JSON reuse without profiles. Field-validated across three
+  measurement gates (see PR discussion): ~3× faster authentication, 100% of login form
+  interaction eliminated, and immunity to the fresh-login rate-limit that fails a concurrent
+  baseline batch.
 
 ## [0.17.0] — 2026-08-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,31 @@ All notable changes to AgenTeX are documented here.
 
 ## [Unreleased]
 ### Added
-- **Session login mode in the test-run path (`login.mode: session`).** Auth `storageState`
-  reuse is now wired into `browser-testing` (sequential + parallel) and `qa-executor`, not
-  just the `define-flow` authoring skill. In `session` mode the orchestrator establishes each
-  unique user's auth once (before parallel dispatch — no thundering herd, no lock) via the
-  driver's own `state-save`/`state-load`, and injects a read-only `AUTH_STATE` + `AUTH_LANDMARK`
-  into each executor, which loads the state and verifies a login-only landmark instead of
-  re-typing a live login. Landmark-verified (never URL-based); an invalid state fails loudly
-  as BLOCKED rather than proceeding unauthenticated. Default stays `fresh` (behavior
-  unchanged; `AUTH_STATE` absent). Motivation: on an authenticated multi-app product,
-  `login.mode: session` was already declarable in config but had no effect in the run path —
-  every run re-typed a full login per spec, which was both the dominant time cost and a
-  flakiness source (post-login timeouts/401s). `storageState` files also drop straight into a
-  compiled `.spec.ts` `storageState:` option for the regression tier.
-- **`references/playwright-cli.md` now documents the driver's Storage commands**
-  (`state-save` / `state-load`, `cookie-*` / `localstorage-*`, `open --persistent --profile`)
-  — previously omitted, though the run path now depends on them.
+- **Session login mode in the test-run path (`login.mode: session`).** Login reuse is now
+  wired into `browser-testing` (sequential + parallel) and `qa-executor`, not just the
+  `define-flow` authoring skill. In `session` mode the orchestrator logs each unique user into
+  a **persistent browser profile** once (before parallel dispatch — no thundering herd), and
+  injects a read-only `AUTH_PROFILE` + `AUTH_LANDMARK` into each executor, which opens
+  `--persistent --profile <dir>` (starting authenticated) and verifies a login-only landmark
+  instead of re-typing a live login. Landmark-verified (never URL-based); an invalid profile
+  fails loudly as BLOCKED. Default stays `fresh` (behavior unchanged; `AUTH_PROFILE` absent).
+  Motivation: on an authenticated multi-app product, `login.mode: session` was already
+  declarable in config but had no effect in the run path — every run re-typed a full login per
+  spec, the dominant time cost and a flakiness source (post-login timeouts/401s).
+- **`references/playwright-cli.md` now documents the driver's Storage commands** — previously
+  omitted, though the run path now depends on them.
+
+### Notes
+- **Reuse mechanism is a persistent `--profile`, not `state-load`.** Field-testing on a
+  Capacitor/Angular app (auth token in `localStorage`) found the driver's `state-load` restores
+  cookies but **not** localStorage across a navigation (Playwright seeds localStorage only at
+  context creation; the CLI's post-hoc load is wiped by the next `goto`), so it silently fails
+  for localStorage-based auth. `session` mode therefore uses `open --persistent --profile`
+  (carries cookies + localStorage, drivable by the same CLI). Concurrency trade-off: a profile
+  dir can't be opened twice at once, so parallel specs sharing a user get a per-executor copy.
+  `state-save`'s `storageState` JSON is still the right artifact for a compiled `.spec.ts`
+  `storageState:` (that path seeds localStorage at newContext). A future open-time
+  `--storage-state` flag on the CLI would give portable-JSON reuse without profiles.
 
 ## [0.17.0] — 2026-08-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to AgenTeX are documented here.
 
+## [Unreleased]
+### Added
+- **Session login mode in the test-run path (`login.mode: session`).** Auth `storageState`
+  reuse is now wired into `browser-testing` (sequential + parallel) and `qa-executor`, not
+  just the `define-flow` authoring skill. In `session` mode the orchestrator establishes each
+  unique user's auth once (before parallel dispatch — no thundering herd, no lock) via the
+  driver's own `state-save`/`state-load`, and injects a read-only `AUTH_STATE` + `AUTH_LANDMARK`
+  into each executor, which loads the state and verifies a login-only landmark instead of
+  re-typing a live login. Landmark-verified (never URL-based); an invalid state fails loudly
+  as BLOCKED rather than proceeding unauthenticated. Default stays `fresh` (behavior
+  unchanged; `AUTH_STATE` absent). Motivation: on an authenticated multi-app product,
+  `login.mode: session` was already declarable in config but had no effect in the run path —
+  every run re-typed a full login per spec, which was both the dominant time cost and a
+  flakiness source (post-login timeouts/401s). `storageState` files also drop straight into a
+  compiled `.spec.ts` `storageState:` option for the regression tier.
+- **`references/playwright-cli.md` now documents the driver's Storage commands**
+  (`state-save` / `state-load`, `cookie-*` / `localstorage-*`, `open --persistent --profile`)
+  — previously omitted, though the run path now depends on them.
+
 ## [0.17.0] — 2026-08-17
 ### Added
 - **Customizable test-user fields — one shared, consumer-owned field schema.** The wizard's

--- a/agents/qa-executor.md
+++ b/agents/qa-executor.md
@@ -15,6 +15,8 @@ ENVIRONMENT:    {{ENVIRONMENT}}            # active environment name ("" for leg
 TEST_DATA:      {{TEST_DATA}}              # defaults + users JSON from environments/<ENVIRONMENT>.json ("" if none)
 WORKING_DIR:    {{WORKING_DIR}}
 SESSION_DIR:    {{SESSION_DIR}}            # e.g. executions/execu_<ts>/browser-sessions/{{SESSION}}
+AUTH_STATE:     {{AUTH_STATE}}             # storageState path to load ("" = fresh mode, log in per spec)
+AUTH_LANDMARK:  {{AUTH_LANDMARK}}          # element true ONLY when logged in ("" if AUTH_STATE empty)
 TEST SPECIFICATION:
 {{TEST_SPEC}}
 === END PARAMETERS ===
@@ -32,6 +34,19 @@ BROWSER TOOL
   re-snapshot after each page load.
 - No `requests` subcommand exists; capture network with `run-code` + a one-line
   page.on('request'/'response') listener.
+
+SESSION AUTH (only when AUTH_STATE is non-empty)
+- The state was prepared by the orchestrator. Load it into your session with the driver's own
+  storage command, then verify the landmark BEFORE scenario 1 — do NOT re-type any login:
+    npx playwright-cli -s={{SESSION}} open {{TARGET_URL}}
+    npx playwright-cli -s={{SESSION}} state-load {{AUTH_STATE}}
+    npx playwright-cli -s={{SESSION}} goto {{TARGET_URL}}          # reload so the state applies
+    npx playwright-cli -s={{SESSION}} find "{{AUTH_LANDMARK}}"     # landmark present == authenticated
+- Confirm the landmark's element is actually visible (verify via `eval` on its computed
+  display, not just DOM presence). If it is absent, STOP and report the whole spec BLOCKED
+  ("auth state invalid: {{AUTH_LANDMARK}}"). You never establish login yourself — the
+  orchestrator owns it; do not fall back to typing credentials.
+- When AUTH_STATE is empty you are in fresh mode: follow the EXECUTION RULES below as written.
 
 WHERE TO SAVE EVIDENCE (your session slice only)
 - Screenshots -> `SESSION_DIR/screenshots/<scenario>.png` (use --filename=, NOT a positional path):
@@ -102,8 +117,11 @@ EXECUTION RULES
 - Execute the scenarios in the TEST SPECIFICATION in the order written.
 - If the spec marks scenarios as a stateful chain, keep them strictly sequential in this one
   session; otherwise treat them as independent steps.
-- Skip auth-gated actions: no real signup / login / checkout. NEVER use real personal data —
-  use disposable values (e.g. qa.tester@example.com). Validation-only checks are allowed.
+- In fresh mode (empty AUTH_STATE): skip auth-gated actions — no real signup / login /
+  checkout. In session mode (AUTH_STATE provided) the context is already authenticated, so
+  auth-gated scenarios ARE in scope. In BOTH modes: NEVER create real accounts, complete real
+  checkout, or use real personal data — use disposable values (e.g. qa.tester@example.com).
+  Validation-only checks are allowed.
 - Never read or print secrets.
 - For any "success" UI, verify the element's computed display/visibility via `eval` — do not
   trust that the text merely exists in the DOM (it may be static markup).

--- a/agents/qa-executor.md
+++ b/agents/qa-executor.md
@@ -15,8 +15,8 @@ ENVIRONMENT:    {{ENVIRONMENT}}            # active environment name ("" for leg
 TEST_DATA:      {{TEST_DATA}}              # defaults + users JSON from environments/<ENVIRONMENT>.json ("" if none)
 WORKING_DIR:    {{WORKING_DIR}}
 SESSION_DIR:    {{SESSION_DIR}}            # e.g. executions/execu_<ts>/browser-sessions/{{SESSION}}
-AUTH_STATE:     {{AUTH_STATE}}             # storageState path to load ("" = fresh mode, log in per spec)
-AUTH_LANDMARK:  {{AUTH_LANDMARK}}          # element true ONLY when logged in ("" if AUTH_STATE empty)
+AUTH_PROFILE:   {{AUTH_PROFILE}}           # persistent browser-profile dir to open authenticated ("" = fresh mode, log in per spec)
+AUTH_LANDMARK:  {{AUTH_LANDMARK}}          # element true ONLY when logged in ("" if AUTH_PROFILE empty)
 TEST SPECIFICATION:
 {{TEST_SPEC}}
 === END PARAMETERS ===
@@ -35,18 +35,19 @@ BROWSER TOOL
 - No `requests` subcommand exists; capture network with `run-code` + a one-line
   page.on('request'/'response') listener.
 
-SESSION AUTH (only when AUTH_STATE is non-empty)
-- The state was prepared by the orchestrator. Load it into your session with the driver's own
-  storage command, then verify the landmark BEFORE scenario 1 — do NOT re-type any login:
-    npx playwright-cli -s={{SESSION}} open {{TARGET_URL}}
-    npx playwright-cli -s={{SESSION}} state-load {{AUTH_STATE}}
-    npx playwright-cli -s={{SESSION}} goto {{TARGET_URL}}          # reload so the state applies
+SESSION AUTH (only when AUTH_PROFILE is non-empty)
+- The orchestrator already logged this user into the persistent profile at AUTH_PROFILE. Open
+  your session FROM that profile — you start authenticated — then verify the landmark BEFORE
+  scenario 1. Do NOT re-type any login:
+    npx playwright-cli -s={{SESSION}} open {{TARGET_URL}} --persistent --profile {{AUTH_PROFILE}}
     npx playwright-cli -s={{SESSION}} find "{{AUTH_LANDMARK}}"     # landmark present == authenticated
 - Confirm the landmark's element is actually visible (verify via `eval` on its computed
-  display, not just DOM presence). If it is absent, STOP and report the whole spec BLOCKED
-  ("auth state invalid: {{AUTH_LANDMARK}}"). You never establish login yourself — the
-  orchestrator owns it; do not fall back to typing credentials.
-- When AUTH_STATE is empty you are in fresh mode: follow the EXECUTION RULES below as written.
+  display, not just DOM presence). If it is absent (e.g. you were redirected to a login page),
+  STOP and report the whole spec BLOCKED ("auth profile invalid: {{AUTH_LANDMARK}}"). You never
+  establish login yourself — the orchestrator owns it; do not fall back to typing credentials.
+- Do NOT use `state-load` to restore the session — it does not persist localStorage across a
+  navigation (see the playwright-cli reference); the persistent profile is the mechanism.
+- When AUTH_PROFILE is empty you are in fresh mode: follow the EXECUTION RULES below as written.
 
 WHERE TO SAVE EVIDENCE (your session slice only)
 - Screenshots -> `SESSION_DIR/screenshots/<scenario>.png` (use --filename=, NOT a positional path):
@@ -117,8 +118,8 @@ EXECUTION RULES
 - Execute the scenarios in the TEST SPECIFICATION in the order written.
 - If the spec marks scenarios as a stateful chain, keep them strictly sequential in this one
   session; otherwise treat them as independent steps.
-- In fresh mode (empty AUTH_STATE): skip auth-gated actions — no real signup / login /
-  checkout. In session mode (AUTH_STATE provided) the context is already authenticated, so
+- In fresh mode (empty AUTH_PROFILE): skip auth-gated actions — no real signup / login /
+  checkout. In session mode (AUTH_PROFILE provided) the session is already authenticated, so
   auth-gated scenarios ARE in scope. In BOTH modes: NEVER create real accounts, complete real
   checkout, or use real personal data — use disposable values (e.g. qa.tester@example.com).
   Validation-only checks are allowed.

--- a/skills/browser-testing/SKILL.md
+++ b/skills/browser-testing/SKILL.md
@@ -78,6 +78,16 @@ lock), so **parallel** specs sharing a user get a per-executor copy of the authe
 `storageState` JSON is still the right artifact for a compiled `.spec.ts` `storageState:`,
 which DOES seed localStorage at newContext — see `references/playwright-cli.md`.)
 
+**Concurrency limit — copies share the refresh token (field-verified).** Copying the profile
+resolves the Chromium **dir lock**, but the copies still carry the **same refresh token**. If
+the app silent-refreshes on load, two copies of one user opened **concurrently** race: the
+first rotates the token and the second gets a `401`/`REFRESH_TOKEN_INVALID` and is bounced to
+login. So a profile copy is NOT an independent concurrent session for the *same* user —
+distinct users run in parallel freely, but **the same user across concurrent specs must run
+sequentially** (or the backend must issue multi-session refresh tokens). Prefer sequential
+scheduling for same-user specs; reserve the copy purely for the dir-lock case where the app
+does not rotate on refresh.
+
 ## Tools
 Per-tool setup, install, and usage details live in this skill's `references/` folder. **Read the
 relevant file BEFORE the first use of that tool in a session**, and again whenever one of its
@@ -195,10 +205,14 @@ Run end to end WITHOUT stopping for per-checkpoint approval; present the final r
    that fails, perform the live login once (saved to the profile automatically) and close.
    Because a persistent profile can't be opened by two browsers at once, for any user shared
    by specs that will run **concurrently**, copy the authed profile dir per executor
-   (`profile-<user>` → `profile-<user>-<session>`) so each has its own. Doing all this BEFORE
-   dispatch keeps executors from logging in at once and makes each profile a ready input. If a
-   user's login can't be established, mark every spec needing that user BLOCKED and do not
-   dispatch it.
+   (`profile-<user>` → `profile-<user>-<session>`) so each clears the dir lock. **But the
+   copies share one refresh token** (see "Session reuse" concurrency limit): if the app
+   silent-refreshes on load, concurrent copies of the *same* user race and one is bounced to
+   login with `REFRESH_TOKEN_INVALID`. So **schedule same-user specs sequentially** by default
+   — the copy only helps when the app does not rotate on refresh. Distinct users dispatch
+   concurrently as normal. Doing all this BEFORE dispatch keeps executors from logging in at
+   once and makes each profile a ready input. If a user's login can't be established, mark
+   every spec needing that user BLOCKED and do not dispatch it.
    Then spawn one **`qa-executor`** subagent per test file, injecting its `SESSION`,
    `SESSION_DIR` (`…/browser-sessions/<session>`), `WORKING_DIR`, `TARGET_URL`, `ENVIRONMENT`,
    `TEST_DATA`, `TEST_SPEC`, and — in `session` mode — `AUTH_PROFILE` (the prepared per-executor

--- a/skills/browser-testing/SKILL.md
+++ b/skills/browser-testing/SKILL.md
@@ -35,6 +35,39 @@ Naming an environment that has no file is an **error**: stop and list the files 
 `environments/`. Never silently fall back to another environment. Record the active
 environment name in `report.md`.
 
+## Session reuse (login modes)
+
+Resolve `login` from `config/project.json` (default `{ "mode": "fresh" }`):
+
+- **`fresh`** — every scenario performs a live login. No state is saved or reused. This is
+  the default and preserves legacy behavior exactly.
+- **`session`** — reuse a saved auth `storageState` per user; perform a live login only when
+  the saved state is missing or fails its landmark check, then save it. This is what lets an
+  authenticated app be tested without re-typing a login in every spec.
+
+`login.session` config:
+
+```json
+"login": {
+  "mode": "session",
+  "stateDir": "test/.auth",
+  "users": {
+    "staff_user": { "landmark": { "present": "role=button[name='Account']" } }
+  }
+}
+```
+
+State path per user is `<stateDir>/<environment>-<userHandle>-state.json`. A landmark is an
+element that is true ONLY when logged in, verified with a `find`/`eval` check — **never by
+URL**. Prefer a `present` landmark; `absent` (a logged-out marker) is allowed as a secondary
+condition. A user with `mode: session` but no landmark is an **error**: stop and report the
+missing landmark; never save or trust an unverified state. The `stateDir` holds live session
+tokens — the consuming project MUST gitignore it.
+
+Session reuse uses `playwright-cli`'s own `state-save` / `state-load` (see the
+`references/playwright-cli.md` "Storage / auth state" section) — the same tool that drives
+the run, so no separate browser or bridge is involved.
+
 ## Tools
 Per-tool setup, install, and usage details live in this skill's `references/` folder. **Read the
 relevant file BEFORE the first use of that tool in a session**, and again whenever one of its
@@ -64,6 +97,9 @@ Always-on rules (full details in the files above):
 - Specs may include **`ui-check:` steps** (compare the live page against a design baseline —
   a Figma frame or a screenshot image) — execute via the **ui-check** skill; read it before
   the first such step. Unresolvable baselines are BLOCKED, never improvised.
+- When `login.mode` is `session` (see "Session reuse" above), the **orchestrator**
+  establishes each user's auth state before any executor runs (see the mode steps below);
+  executors never perform login themselves — they receive a prepared state to load.
 - Helper scripts (all in `${CLAUDE_PLUGIN_ROOT}/skills/browser-testing/scripts/`, each prints
   one JSON line): `preflight.js` — check all tools in one call at session start;
   `init_run.js [--sessions label1,label2]` — create the whole execution tree (use instead of
@@ -117,8 +153,12 @@ Follow this loop and STOP for approval at each checkpoint. Do not skip ahead.
 3. **EXECUTE** — Before the first browser action, run `init_run.js` (no `--sessions` needed)
    to create `executions/execu_<timestamp>/` and get this run's unique session name; prefix
    EVERY `playwright-cli` command with `-s=<that name>` (never run a bare, default-session
-   command). Run scenarios one at a time. After each scenario, report PASS/FAIL with evidence
-   (screenshot + observed vs. expected).
+   command). **In `session` login mode**, before the first scenario, establish the run's
+   user: `open <target>` → `state-load <path>` → verify the landmark; if it fails, perform
+   the live login once then `state-save <path>`, and continue from the authenticated session.
+   (In `fresh` mode skip this — scenarios log in live as written.) Run scenarios one at a
+   time. After each scenario, report PASS/FAIL with evidence (screenshot + observed vs.
+   expected).
    → Checkpoint: pause after each scenario before moving to the next.
 4. **REPORT** — Save screenshots/logs under `browser-sessions/<session>/` in the run folder,
    then write `report.md` + `bugs/` there, and close your session (`-s=<session> close` —
@@ -139,13 +179,22 @@ Run end to end WITHOUT stopping for per-checkpoint approval; present the final r
    - **First run:** if no `test/` specs exist yet, copy the bundled samples from
      `${CLAUDE_PLUGIN_ROOT}/test/suite1/` into `./test/suite1/` as an editable starting point,
      and tell the user to adapt them to their app before a real regression.
-3. **DISPATCH** — Spawn one **`qa-executor`** subagent per test file, injecting its `SESSION`,
+3. **DISPATCH** — **Session login mode only, first — PREPARE AUTH:** compute the set of
+   *unique* users across all planned specs and, once each, in an orchestrator-owned session:
+   `open <target>` → `state-load <path>` → landmark check; if that fails, perform the live
+   login once, `state-save <path>`, and close. Doing this BEFORE dispatch keeps parallel
+   executors from all logging in at once (no lock needed) and makes the resulting
+   `storageState` files read-only inputs. If a user's login can't be established, mark every
+   spec needing that user BLOCKED and do not dispatch it.
+   Then spawn one **`qa-executor`** subagent per test file, injecting its `SESSION`,
    `SESSION_DIR` (`…/browser-sessions/<session>`), `WORKING_DIR`, `TARGET_URL`, `ENVIRONMENT`,
-   `TEST_DATA`, and `TEST_SPEC`. `ENVIRONMENT` is the resolved environment name (empty for
-   legacy projects); `TEST_DATA` is the environment's `defaults` + `users` JSON (secrets left
-   as `{ envSecret }` refs — the executor resolves them only at use time and never prints
-   them). Each uses its own `-s=<session>`. Launch them in a single batch so they run
-   concurrently. Expect ~6–8 browser sessions to run at once; the rest queue automatically.
+   `TEST_DATA`, `TEST_SPEC`, and — in `session` mode — `AUTH_STATE` (the prepared state path
+   for the spec's user) and `AUTH_LANDMARK` (that user's landmark); both are empty in `fresh`
+   mode. `ENVIRONMENT` is the resolved environment name (empty for legacy projects);
+   `TEST_DATA` is the environment's `defaults` + `users` JSON (secrets left as `{ envSecret }`
+   refs — the executor resolves them only at use time and never prints them). Each uses its
+   own `-s=<session>`. Launch them in a single batch so they run concurrently. Expect ~6–8
+   browser sessions to run at once; the rest queue automatically.
 4. **MERGE** — Collect each subagent's report. **Resolve deferred ui-check questions first:**
    executors cannot ask the user mid-run, so a `ui-check:` step needing a confirmation
    (exact-mode suspected rendering noise) or a stop-and-ask (an unintelligible variant set)

--- a/skills/browser-testing/SKILL.md
+++ b/skills/browser-testing/SKILL.md
@@ -41,32 +41,42 @@ Resolve `login` from `config/project.json` (default `{ "mode": "fresh" }`):
 
 - **`fresh`** — every scenario performs a live login. No state is saved or reused. This is
   the default and preserves legacy behavior exactly.
-- **`session`** — reuse a saved auth `storageState` per user; perform a live login only when
-  the saved state is missing or fails its landmark check, then save it. This is what lets an
-  authenticated app be tested without re-typing a login in every spec.
+- **`session`** — reuse a per-user authenticated **persistent browser profile**; perform a
+  live login only when the profile is missing or fails its landmark check, then it is saved
+  on disk automatically. This is what lets an authenticated app be tested without re-typing a
+  login in every spec.
 
 `login.session` config:
 
 ```json
 "login": {
   "mode": "session",
-  "stateDir": "test/.auth",
+  "profileDir": "test/.auth",
   "users": {
-    "staff_user": { "landmark": { "present": "role=button[name='Account']" } }
+    "staff_user": { "landmark": { "present": "[aria-label='Sign out']" } }
   }
 }
 ```
 
-State path per user is `<stateDir>/<environment>-<userHandle>-state.json`. A landmark is an
-element that is true ONLY when logged in, verified with a `find`/`eval` check — **never by
-URL**. Prefer a `present` landmark; `absent` (a logged-out marker) is allowed as a secondary
-condition. A user with `mode: session` but no landmark is an **error**: stop and report the
-missing landmark; never save or trust an unverified state. The `stateDir` holds live session
-tokens — the consuming project MUST gitignore it.
+Each user's profile is `<profileDir>/profile-<userHandle>/` — a real on-disk Chromium
+user-data dir, opened via `open --persistent --profile <dir>`. A landmark is an element that
+is true ONLY when logged in, verified with a `find`/`eval` check — **never by URL**. Prefer a
+`present` landmark; `absent` (a logged-out marker) is allowed as a secondary condition. A user
+with `mode: session` but no landmark is an **error**: stop and report the missing landmark;
+never trust an unverified profile. The `profileDir` holds live session state — the consuming
+project MUST gitignore it.
 
-Session reuse uses `playwright-cli`'s own `state-save` / `state-load` (see the
-`references/playwright-cli.md` "Storage / auth state" section) — the same tool that drives
-the run, so no separate browser or bridge is involved.
+**Why a persistent profile, not `state-save`/`state-load`:** the driver's `state-load` does
+not restore **localStorage** across a navigation (Playwright seeds localStorage only at
+context creation; the CLI's post-hoc load is wiped on the next `goto`) — so it silently fails
+for the very common case of an app keeping its auth token in localStorage (SPA / Capacitor /
+JWT-in-localStorage; field-verified). A persistent `--profile` is an on-disk profile that
+carries cookies AND localStorage across opens, and is drivable by the same `playwright-cli`
+that runs the test. Trade-off: a profile dir can't be opened by two browsers at once (dir
+lock), so **parallel** specs sharing a user get a per-executor copy of the authed profile
+(see DISPATCH); **sequential** runs share the one profile directly. (`state-save`'s
+`storageState` JSON is still the right artifact for a compiled `.spec.ts` `storageState:`,
+which DOES seed localStorage at newContext — see `references/playwright-cli.md`.)
 
 ## Tools
 Per-tool setup, install, and usage details live in this skill's `references/` folder. **Read the
@@ -154,11 +164,11 @@ Follow this loop and STOP for approval at each checkpoint. Do not skip ahead.
    to create `executions/execu_<timestamp>/` and get this run's unique session name; prefix
    EVERY `playwright-cli` command with `-s=<that name>` (never run a bare, default-session
    command). **In `session` login mode**, before the first scenario, establish the run's
-   user: `open <target>` → `state-load <path>` → verify the landmark; if it fails, perform
-   the live login once then `state-save <path>`, and continue from the authenticated session.
-   (In `fresh` mode skip this — scenarios log in live as written.) Run scenarios one at a
-   time. After each scenario, report PASS/FAIL with evidence (screenshot + observed vs.
-   expected).
+   user: `open <target> --persistent --profile <profileDir>/profile-<user>` → verify the
+   landmark; if it fails (missing/expired profile), perform the live login once — it is saved
+   to the profile automatically — and continue from the authenticated session. (In `fresh`
+   mode skip this — scenarios log in live as written.) Run scenarios one at a time. After each
+   scenario, report PASS/FAIL with evidence (screenshot + observed vs. expected).
    → Checkpoint: pause after each scenario before moving to the next.
 4. **REPORT** — Save screenshots/logs under `browser-sessions/<session>/` in the run folder,
    then write `report.md` + `bugs/` there, and close your session (`-s=<session> close` —
@@ -181,16 +191,19 @@ Run end to end WITHOUT stopping for per-checkpoint approval; present the final r
      and tell the user to adapt them to their app before a real regression.
 3. **DISPATCH** — **Session login mode only, first — PREPARE AUTH:** compute the set of
    *unique* users across all planned specs and, once each, in an orchestrator-owned session:
-   `open <target>` → `state-load <path>` → landmark check; if that fails, perform the live
-   login once, `state-save <path>`, and close. Doing this BEFORE dispatch keeps parallel
-   executors from all logging in at once (no lock needed) and makes the resulting
-   `storageState` files read-only inputs. If a user's login can't be established, mark every
-   spec needing that user BLOCKED and do not dispatch it.
+   `open <target> --persistent --profile <profileDir>/profile-<user>` → landmark check; if
+   that fails, perform the live login once (saved to the profile automatically) and close.
+   Because a persistent profile can't be opened by two browsers at once, for any user shared
+   by specs that will run **concurrently**, copy the authed profile dir per executor
+   (`profile-<user>` → `profile-<user>-<session>`) so each has its own. Doing all this BEFORE
+   dispatch keeps executors from logging in at once and makes each profile a ready input. If a
+   user's login can't be established, mark every spec needing that user BLOCKED and do not
+   dispatch it.
    Then spawn one **`qa-executor`** subagent per test file, injecting its `SESSION`,
    `SESSION_DIR` (`…/browser-sessions/<session>`), `WORKING_DIR`, `TARGET_URL`, `ENVIRONMENT`,
-   `TEST_DATA`, `TEST_SPEC`, and — in `session` mode — `AUTH_STATE` (the prepared state path
-   for the spec's user) and `AUTH_LANDMARK` (that user's landmark); both are empty in `fresh`
-   mode. `ENVIRONMENT` is the resolved environment name (empty for legacy projects);
+   `TEST_DATA`, `TEST_SPEC`, and — in `session` mode — `AUTH_PROFILE` (the prepared per-executor
+   profile dir for the spec's user) and `AUTH_LANDMARK` (that user's landmark); both are empty
+   in `fresh` mode. `ENVIRONMENT` is the resolved environment name (empty for legacy projects);
    `TEST_DATA` is the environment's `defaults` + `users` JSON (secrets left as `{ envSecret }`
    refs — the executor resolves them only at use time and never prints them). Each uses its
    own `-s=<session>`. Launch them in a single batch so they run concurrently. Expect ~6–8

--- a/skills/browser-testing/references/playwright-cli.md
+++ b/skills/browser-testing/references/playwright-cli.md
@@ -47,6 +47,19 @@ when a `playwright-cli` command behaves unexpectedly.
   cleanup AND confirms no other execution is running.
 - `show` — open the playwright dashboard to watch sessions (works for headless too).
 
+## Storage / auth state
+- `state-save [file]` — write the current session's cookies + localStorage as a
+  Playwright-native `storageState` JSON. `state-load <file>` — load one into a session (call
+  it right after `open`, then `goto`/`reload` so it applies). This is how the `session` login
+  mode reuses a login across runs (see browser-testing SKILL.md "Session reuse"), and the
+  files feed a compiled `.spec.ts` `storageState:` option unchanged.
+- Granular access if you need it: `cookie-*`, `localstorage-*`, `sessionstorage-*`.
+- `open --persistent --profile <dir>` is an alternative reuse model (a persistent user-data
+  dir per identity); `state-save`/`state-load` is preferred — portable and regression-tier
+  compatible. `storageState` carries cookies + localStorage ONLY — an app that holds its
+  token purely in memory won't resume; the landmark check makes that fail loudly (BLOCKED),
+  not silently proceed unauthenticated.
+
 ## Concurrency
 - Effective parallelism is bound by the machine's CPU/RAM (each session is a real Chromium):
   plan for ~6–8 concurrent sessions; the harness queues the rest automatically.

--- a/skills/browser-testing/references/playwright-cli.md
+++ b/skills/browser-testing/references/playwright-cli.md
@@ -54,8 +54,11 @@ when a `playwright-cli` command behaves unexpectedly.
   keep their auth token in **localStorage** (SPA / Capacitor / JWT-in-localStorage), and it is
   driven by the same `playwright-cli` as the test. Caveat: one profile dir can't be opened by
   two browsers at once (dir lock) — for concurrent same-user sessions, copy the authed profile
-  per session. This is how `session` login mode works (see browser-testing SKILL.md "Session
-  reuse").
+  per session. But the copies **share one refresh token**: if the app silent-refreshes on
+  load, concurrent copies of the same user race and one is bounced to login
+  (`REFRESH_TOKEN_INVALID`), so schedule same-user specs **sequentially** unless the app does
+  not rotate on refresh (distinct users are fine concurrently). This is how `session` login
+  mode works (see browser-testing SKILL.md "Session reuse").
 - **Do NOT rely on `state-load` for a localStorage-based login.** `state-save [file]` /
   `state-load <file>` round-trip a Playwright `storageState` JSON, but Playwright can only seed
   localStorage at context *creation* — the CLI's post-hoc `state-load` restores cookies while

--- a/skills/browser-testing/references/playwright-cli.md
+++ b/skills/browser-testing/references/playwright-cli.md
@@ -48,17 +48,25 @@ when a `playwright-cli` command behaves unexpectedly.
 - `show` — open the playwright dashboard to watch sessions (works for headless too).
 
 ## Storage / auth state
-- `state-save [file]` — write the current session's cookies + localStorage as a
-  Playwright-native `storageState` JSON. `state-load <file>` — load one into a session (call
-  it right after `open`, then `goto`/`reload` so it applies). This is how the `session` login
-  mode reuses a login across runs (see browser-testing SKILL.md "Session reuse"), and the
-  files feed a compiled `.spec.ts` `storageState:` option unchanged.
+- **Reusing a login across runs → `open --persistent --profile <dir>`.** A real on-disk
+  Chromium user-data dir: log a user in once into the profile, and every later `open` with the
+  same `--profile` starts already authenticated. This is the reliable mechanism for apps that
+  keep their auth token in **localStorage** (SPA / Capacitor / JWT-in-localStorage), and it is
+  driven by the same `playwright-cli` as the test. Caveat: one profile dir can't be opened by
+  two browsers at once (dir lock) — for concurrent same-user sessions, copy the authed profile
+  per session. This is how `session` login mode works (see browser-testing SKILL.md "Session
+  reuse").
+- **Do NOT rely on `state-load` for a localStorage-based login.** `state-save [file]` /
+  `state-load <file>` round-trip a Playwright `storageState` JSON, but Playwright can only seed
+  localStorage at context *creation* — the CLI's post-hoc `state-load` restores cookies while
+  localStorage is wiped on the next `goto` (field-verified on a Capacitor/Angular app whose
+  token lives in `localStorage`: it redirected to `/login` after `state-load` + navigate).
+  `state-load` is fine for cookie-only sessions; and the `storageState` JSON that `state-save`
+  produces still feeds a compiled `.spec.ts` `storageState:` option unchanged (that path DOES
+  seed localStorage, at newContext).
 - Granular access if you need it: `cookie-*`, `localstorage-*`, `sessionstorage-*`.
-- `open --persistent --profile <dir>` is an alternative reuse model (a persistent user-data
-  dir per identity); `state-save`/`state-load` is preferred — portable and regression-tier
-  compatible. `storageState` carries cookies + localStorage ONLY — an app that holds its
-  token purely in memory won't resume; the landmark check makes that fail loudly (BLOCKED),
-  not silently proceed unauthenticated.
+- The cleanest future fix for portable-JSON reuse in the CLI would be an open-time
+  `--storage-state <file>` flag (seed at newContext) — not available in the CLI today.
 
 ## Concurrency
 - Effective parallelism is bound by the machine's CPU/RAM (each session is a real Chromium):


### PR DESCRIPTION
# PR: Wire `optimize-login` session reuse into the test-run path

## Where this comes from (not a speculative refactor)

We run AgenTeX as the QA engine for a production **multi-app product** — several
role-based, separately-authenticated web apps plus a live push-event channel — driven by a
story-tracker QA loop with both sequential and parallel `qa-executor` runs. This PR is the direct result of that usage: after a stretch of runs felt slower and
flakier than they should, we audited **20 real `qa-executor` transcripts across 3 sessions
(2,708 tool calls)** to find out *why* — and it traced to one structural gap in AgenTeX,
not our specs. The change below is what we've concluded needs to exist; everything in it is
grounded in numbers from those runs.

## What we measured (the evidence)

Across those 20 authenticated-app executor runs:

| Signal | Measured | What it means |
|---|---|---|
| `storageState` reuse | **0 / 20** runs | login is never reused — every run pays it from scratch |
| Manual credential fills | **18 / 20** runs, in the first ~20 tool calls | each spec re-types a full live login before any real testing |
| Tool results with timeout/401 | **~11%**, clustered right after fresh logins (worst run: 30) | the fresh-login window is itself a *flakiness source*, not just slow |
| `login.mode: session` in our config | declared, **silently did nothing** | we had already opted into session reuse — the plugin never enforced it |

That last row is the sharpest one: our `config/project.json` already said
`"login": { "mode": "session" }`. We assumed it worked. It doesn't — nothing in the run
path reads it — so we were paying full login on every run while believing we weren't. That
is a real user hitting a declared-but-unwired feature, which is exactly the kind of thing
worth fixing upstream rather than papering over per-project.

## Root cause

`optimize-login` (landmark-verified `storageState` reuse) is only referenced from the
**authoring** skill (`define-flow`, SETUP step 3). The **execution** path never uses it:

- `browser-testing/SKILL.md` (sequential *and* parallel run modes) has no mention of
  session reuse — every run logs in live.
- `agents/qa-executor.md` has no auth-state parameter, and its EXECUTION RULES say
  *"Skip auth-gated actions: no real signup / login / checkout."* — so for an authenticated
  app, each spec works around that by re-typing a live login, and `login.mode: session`
  has nowhere to take effect.

## Key fact: the driver already supports this natively

`@playwright/cli` (the `playwright-cli` the executor drives with) ships
`state-save [filename]` / `state-load <filename>` (Playwright-native storageState), plus
granular `cookie-*` / `localstorage-*` commands and an `open --persistent --profile <dir>`
mode. AgenTeX just never calls them — and the `references/playwright-cli.md` doc doesn't
even mention them. So session reuse is a pure skill/prompt/doc change against a capability
the tool already has; **no `session.js` cross-browser bridging is needed** (the executor
saves/loads state with the same tool it drives with).

## Change

Make `login.mode: session` a real execution contract, using `playwright-cli`'s own
`state-save` / `state-load` (no new auth logic, one browser tool):

1. **`browser-testing/SKILL.md`**
   - New "Session reuse (login modes)" resolution block: `fresh` (default; always live
     login — current behavior) vs `session` (reuse a valid `storageState`, fall back to a
     single live login only when missing/invalid).
   - **Orchestrator prepares auth before dispatch** (concurrency-safe): resolve the set of
     *unique* users the run needs and, once each, `state-load` + landmark check → else
     live-login-once + `state-save`. This avoids a thundering herd of parallel executors
     all logging in at once, without any filesystem lock.
   - Pass `AUTH_STATE` + `AUTH_LANDMARK` to each executor; the `storageState` files are
     then **read-only inputs**.

2. **`agents/qa-executor.md`**
   - New `AUTH_STATE` / `AUTH_LANDMARK` parameters and a "SESSION AUTH" section: when
     `AUTH_STATE` is provided, start every browser context from that `storageState` and
     verify the landmark before scenario 1 — never re-type login. If the landmark fails,
     return **BLOCKED** (the orchestrator owns login; the executor never improvises one).
   - Scope the "skip auth-gated actions" rule to the `fresh`/no-state case; when a
     pre-authenticated `AUTH_STATE` is supplied, auth-gated scenarios are in scope.

Backward compatible: with no `login` block (or `mode: fresh`), behavior is unchanged and
`AUTH_STATE` is simply absent.

## Impact on the plugin (tied to what we measured)

For any project testing an authenticated app — which is most non-trivial products — this
changes three things we felt directly:

1. **Speed.** Login goes from paid *per spec* (18/20 runs above) to paid *once per user per
   run*. In a parallel regression fanning out N specs for the same role, that's N logins →
   1. The plugin's own `optimize-login` README already quantifies a single login at
   ~197s→~8s once cached; this PR is what lets the *run path* actually collect that saving,
   not just the authoring path.
2. **Reliability.** The ~11% post-login timeout/401 window disappears because scenarios
   start from an already-established, landmark-verified session instead of racing a
   just-completed login. This was our flakiness, and it's structural, not spec-specific.
3. **It makes `login.mode: session` mean something.** Today it's a config key with no
   effect. After this PR the declared contract is enforced end to end — no more silent
   no-op.

It also unlocks the parallel mode for authenticated products at all: an executor told to
"skip auth-gated actions" can't test anything behind a login without the per-spec re-login
hack. With a pre-authenticated `AUTH_STATE`, auth-gated flows become first-class.

And it pays forward into regression: `state-save` writes Playwright-native `storageState`,
so the exact files this produces drop straight into a compiled `.spec.ts` `storageState:`
option — the natural next step for turning proven agentic specs into fast replays.

`optimize-login`/`session.js` stays as-is (still used by `define-flow` for authoring); this
PR does not depend on it. A project may still use its landmark-guarded `saveSession` for the
one-time orchestrator save — but the default, tool-coherent path is `playwright-cli
state-save` / `state-load`.

## Scope discipline

Deliberately small and backward-compatible: with no `login` block (or `mode: fresh`),
behavior is byte-for-byte unchanged and `AUTH_STATE` is simply absent. No new dependency, no
new auth logic — it wires an existing plugin skill and an existing driver capability into
the one path that was skipping both. Everything here is a documentation/orchestration change
justified by the run data above.

## Notes / follow-ups (not in this PR)

- State files hold live session tokens — the consuming project must gitignore its
  `stateDir` (documented in the skill, enforced by the project).
- Applications that keep their auth token in memory (not cookies/localStorage) can't be
  resumed from `storageState` — `session.js` already documents this; the landmark check
  makes it fail loudly (BLOCKED) rather than silently proceed unauthenticated.


## Field Validation & Benchmarks

This change was validated end-to-end across **three measurement gates** before proposing it — not just reasoned about. All three converge on ~3× faster authentication and 100% elimination of login form interaction.

**Gate 1 — mechanism microbenchmark (precise, script-timed).** A Node+Playwright script timed `goto → login-only-landmark-visible`, cold (fresh login) vs warm (persistent profile), 3 iterations, agent overhead excluded: **doctor 1683 ms → 541 ms = 3.11×** (±3%), 3 form fills → 0. This gate is also what caught the original `state-load`/localStorage correctness bug that led to the persistent-`--profile` mechanism in this PR.

**Gate 2 — real-flow A/B (in actual story flows).** Fresh-login vs profile-reuse inside real flows: **secretary** 3 steps → 0, ~3.2× faster; **patient** full register+OTP (10 steps) → 0, ~5.5× faster — and the downstream backend behavior was **byte-identical** in both arms (same request contract, `201`, `nextAction`, route), confirming reuse changes nothing about correctness.

**Gate 3 — plugin-level batch A/B (this PR overlaid on the real plugin).** The actual `agentex:qa-executor` agent ran a fixture-light identity/landing batch (one spec per role) twice — pristine plugin (fresh login) vs this PR overlaid (profile reuse):

| | Baseline (fresh login) | Patched (profile reuse) |
|---|---|---|
| Total logins | 3 | **0** |
| Total tool calls | 105 | **54** (−49%) |
| Total wall-clock | ~16.1 min | **~5.5 min** (~2.9× faster) |

Per-role wall-clock speedup 2.55×–3.32×, consistent with Gate 1. (Absolute times are agent-inflated; the ratios, tool-call counts, and login counts are the robust signals.)

**Reliability finding:** the baseline's *concurrent* batch attempt **failed outright** — logging multiple specs into one account concurrently tripped an auth-endpoint rate-limit/lockout. The patched arm never touches the auth endpoint, so it is immune. Fresh-login-per-spec isn't just slower, it's fragile under a regression batch.

**Concurrency limit (documented in the skill).** Persistent-profile *copies* share the same **refresh token**, so two copies of one user opened concurrently race — the first rotates the token and the second gets `REFRESH_TOKEN_INVALID`. The per-executor copy fixes the Chromium **dir lock** but not refresh-token rotation: same-user specs must run **sequentially** unless the app does not rotate on refresh (distinct users run concurrently freely).
